### PR TITLE
refactor: Change std::initializer_list to std::array

### DIFF
--- a/examples/Bytestreams/Bytestreams.ino
+++ b/examples/Bytestreams/Bytestreams.ino
@@ -15,15 +15,17 @@
 
 #include "SettingsManagerESP32.h"
 
+// Example of Bytestream values with string data (size includes null terminator)
+
 // Default values
-const NVS::ByteStream bs1_default = {reinterpret_cast<const uint8_t*>("111"), 3};
-const NVS::ByteStream bs2_default = {reinterpret_cast<const uint8_t*>("222"), 3};
-const NVS::ByteStream bs3_default = {reinterpret_cast<const uint8_t*>("333"), 3};
+const NVS::ByteStream bs1_default = {reinterpret_cast<const uint8_t*>("111"), 4};
+const NVS::ByteStream bs2_default = {reinterpret_cast<const uint8_t*>("222"), 4};
+const NVS::ByteStream bs3_default = {reinterpret_cast<const uint8_t*>("333"), 4};
 
 // New values
-const NVS::ByteStream bs1_new = {reinterpret_cast<const uint8_t*>("aaaaaa"), 6};
-const NVS::ByteStream bs2_new = {reinterpret_cast<const uint8_t*>("bbbbbb"), 6};
-const NVS::ByteStream bs3_new = {reinterpret_cast<const uint8_t*>("cccccc"), 6};
+const NVS::ByteStream bs1_new = {reinterpret_cast<const uint8_t*>("aaaaaa"), 7};
+const NVS::ByteStream bs2_new = {reinterpret_cast<const uint8_t*>("bbbbbb"), 7};
+const NVS::ByteStream bs3_new = {reinterpret_cast<const uint8_t*>("cccccc"), 7};
 
 const NVS::ByteStream* bs_new_values[] = {&bs1_new, &bs2_new, &bs3_new};
 
@@ -34,7 +36,8 @@ const NVS::ByteStream* bs_new_values[] = {&bs1_new, &bs2_new, &bs3_new};
   X(BS_3, "bs 3", bs3_default, true)
 
 enum class ByteStreams : uint8_t { BYTESTREAMS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<NVS::ByteStream, ByteStreams> bs = {BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<NVS::ByteStream, ByteStreams, SETTINGS_COUNT(BYTESTREAMS)> bs = {
+  BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)};
 
 void setup() {
   Serial.begin(115200);

--- a/examples/Integers/Integers.ino
+++ b/examples/Integers/Integers.ino
@@ -22,7 +22,7 @@
   X(UInt_3, "UInt 3", 3, true)
 
 enum class UInts : uint8_t { UINTS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<uint32_t, UInts> uints = {UINTS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<uint32_t, UInts, SETTINGS_COUNT(UINTS)> uints = {UINTS(SETTINGS_EXPAND_SETTINGS)};
 
 void setup() {
   Serial.begin(115200);

--- a/examples/Strings/Strings.ino
+++ b/examples/Strings/Strings.ino
@@ -22,7 +22,8 @@
   X(Str_3, "Str 3", "str 3", true)
 
 enum class Strings : uint8_t { STRINGS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<const char*, Strings> strings = {STRINGS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<const char*, Strings, SETTINGS_COUNT(STRINGS)> strings = {
+  STRINGS(SETTINGS_EXPAND_SETTINGS)};
 
 void setup() {
   Serial.begin(115200);

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "SettingsManagerESP32",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "authors": {
     "name": "Maximiliano Ramirez",
     "email": "maximiliano.ramirezbravo@gmail.com"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SettingsManagerESP32
-version=2.1.0
+version=3.0.0
 author=Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
 maintainer=Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
 sentence=Abstraction over ESP32 Arduino Preferences library to make your life easier.

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,13 +10,13 @@
 
 [platformio]
 lib_dir = .
-src_dir = examples/Integers
+; src_dir = examples/Integers
 ; src_dir = examples/Strings
-; src_dir = examples/Bytestreams
+src_dir = examples/Bytestreams
 
 [env:esp32-s3]
-; platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip
-platform = espressif32@6.5.0
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip
+; platform = espressif32@6.5.0
 board = esp32-s3-devkitc-1
 framework = arduino
 

--- a/src/SettingsManagerESP32.h
+++ b/src/SettingsManagerESP32.h
@@ -20,9 +20,8 @@
 #endif
 
 // X-macros
-#define SETTINGS_EXPAND_ENUM_CLASS(name, text, value, formatteable) name,
-#define SETTINGS_EXPAND_SETTINGS(name, text, value, formatteable) \
-  {#name, text, value, formatteable},
+#define SETTINGS_EXPAND_ENUM_CLASS(name, text, value, formattable) name,
+#define SETTINGS_EXPAND_SETTINGS(name, text, value, formattable)   {#name, text, value, formattable},
 
 // NVS (non-volatile storage ESP32)
 extern Preferences nvs;
@@ -45,7 +44,7 @@ struct Setting {
   const char* key;
   const char* hint;
   const T default_value;
-  const bool formatteable;
+  const bool formattable;
 };
 
 // Policy types
@@ -308,17 +307,17 @@ class ISettings {
   virtual bool hasKey(const char* key, size_t& index_found) = 0;
 
   /**
-   * @brief Check if a setting is formatteable.
+   * @brief Check if a setting is formattable.
    * @param index Index in the list
-   * @return true Formatteable
-   * @return false Not formatteable or index out of bounds
+   * @return true Formattable
+   * @return false Not formattable or index out of bounds
    */
-  virtual bool isFormatteable(size_t index) = 0;
+  virtual bool isFormattable(size_t index) = 0;
 
   /**
    * @brief Format a setting to its default value.
    * @param index Index in the list
-   * @param force Force the format even if the setting is not formatteable
+   * @param force Force the format even if the setting is not formattable
    * @return true OK
    * @return false Failed to format or index out of bounds
    */
@@ -326,7 +325,7 @@ class ISettings {
 
   /**
    * @brief Format all settings to their default values.
-   * @param force Force the format even if the setting is not formatteable
+   * @param force Force the format even if the setting is not formattable
    * @return size_t Number of errors while trying to format
    */
   virtual size_t formatAll(bool force = false) = 0;
@@ -458,41 +457,41 @@ class Settings : public ISettings {
   }
 
   /**
-   * @brief Check if a setting is formatteable.
+   * @brief Check if a setting is formattable.
    * @param index Index in the list
-   * @return true Formatteable
-   * @return false Not formatteable or index out of bounds
+   * @return true Formattable
+   * @return false Not formattable or index out of bounds
    */
-  bool isFormatteable(size_t index) override {
+  bool isFormattable(size_t index) override {
     if (index >= getSize()) return false;
-    return _list.begin()[index].formatteable;
+    return _list.begin()[index].formattable;
   }
 
   /**
    * @brief Format a setting to its default value.
    * @param index Index in the list
-   * @param force Force the format even if the setting is not formatteable
+   * @param force Force the format even if the setting is not formattable
    * @return true OK
    * @return false Failed to format or index out of bounds
    */
   bool format(size_t index, bool force = false) override {
     if (index >= getSize()) return false;
 
-    if (!isFormatteable(index) && !force) return false;
+    if (!isFormattable(index) && !force) return false;
 
     return setValueImpl(static_cast<ENUM>(index), getDefaultValue(index), true);
   }
 
   /**
    * @brief Format all settings to their default values.
-   * @param force Force the format even if the setting is not formatteable
+   * @param force Force the format even if the setting is not formattable
    * @return size_t Number of errors while trying to format
    */
   size_t formatAll(bool force = false) override {
     size_t errors = 0;
 
     for (size_t i = 0; i < getSize(); i++) {
-      if (!isFormatteable(i) && !force) continue;
+      if (!isFormattable(i) && !force) continue;
 
       if (!setValueImpl(static_cast<ENUM>(i), getDefaultValue(i), true)) errors++;
     }
@@ -503,7 +502,7 @@ class Settings : public ISettings {
   /**
    * @brief Format a setting to its default value.
    * @param ENUM Selected setting
-   * @param force Force the format even if the setting is not formatteable
+   * @param force Force the format even if the setting is not formattable
    * @return true OK
    * @return false Failed to format
    */
@@ -583,13 +582,13 @@ class Settings : public ISettings {
   }
 
   /**
-   * @brief Check if a setting is formatteable.
+   * @brief Check if a setting is formattable.
    * @param ENUM Selected setting
-   * @return true Formatteable
-   * @return false Not formatteable
+   * @return true Formattable
+   * @return false Not formattable
    */
-  bool isFormatteable(ENUM setting) {
-    return _list.begin()[static_cast<size_t>(setting)].formatteable;
+  bool isFormattable(ENUM setting) {
+    return _list.begin()[static_cast<size_t>(setting)].formattable;
   }
 
   /**

--- a/test/test_settings.cpp
+++ b/test/test_settings.cpp
@@ -74,25 +74,29 @@ NVS::ByteStream new_bytestream[NVS_VALUES] = {
 
 // Instantiation of settings
 enum class Bools : uint8_t { BOOLS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<bool, Bools> bools = {BOOLS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<bool, Bools, SETTINGS_COUNT(BOOLS)> bools = {BOOLS(SETTINGS_EXPAND_SETTINGS)};
 
 enum class UInt32s : uint8_t { UINT32S(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<uint32_t, UInt32s> uint32s = {UINT32S(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<uint32_t, UInt32s, SETTINGS_COUNT(UINT32S)> uint32s = {
+  UINT32S(SETTINGS_EXPAND_SETTINGS)};
 
 enum class Int32s : uint8_t { INT32S(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<int32_t, Int32s> int32s = {INT32S(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<int32_t, Int32s, SETTINGS_COUNT(INT32S)> int32s = {INT32S(SETTINGS_EXPAND_SETTINGS)};
 
 enum class Floats : uint8_t { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<float, Floats> floats = {FLOATS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<float, Floats, SETTINGS_COUNT(FLOATS)> floats = {FLOATS(SETTINGS_EXPAND_SETTINGS)};
 
 enum class Doubles : uint8_t { DOUBLES(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<double, Doubles> doubles = {DOUBLES(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<double, Doubles, SETTINGS_COUNT(DOUBLES)> doubles = {
+  DOUBLES(SETTINGS_EXPAND_SETTINGS)};
 
 enum class Strings : uint8_t { STRINGS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<const char*, Strings> strings = {STRINGS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<const char*, Strings, SETTINGS_COUNT(STRINGS)> strings = {
+  STRINGS(SETTINGS_EXPAND_SETTINGS)};
 
 enum class ByteStreams : uint8_t { BYTESTREAMS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<NVS::ByteStream, ByteStreams> bytestreams = {BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<NVS::ByteStream, ByteStreams, SETTINGS_COUNT(BYTESTREAMS)> bytestreams = {
+  BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)};
 
 NVS::ISettings* settings[] = {&bools, &uint32s, &int32s, &floats, &doubles, &strings, &bytestreams};
 constexpr size_t settings_size = sizeof(settings) / sizeof(settings[0]);


### PR DESCRIPTION
- Arduino core v3 makes the `std::initializer_list` to have undefined behavior with some setting types.
- Changed `std::initializer_list` to `std::array` and updated the constructor.
- Added a macro to calculate automatically the number of settings in a X-macro for the array template parameter.