### PR TITLE
refactor!: Use only ESP-IDF NVS library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .pio
 .vscode
 logs
+.github/copilot-instructions.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 
 <p align="center">
-  <b>Manage your ESP32 Preferences easily!</b>
+  <b>Manage your ESP32 settings with ease!</b>
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
   <br><br>
   <a href="https://ko-fi.com/alkonosst">
     <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi">
-    </a>
+  </a>
 </p>
 
 ---
@@ -34,32 +34,36 @@
     - [What is inside the library](#what-is-inside-the-library)
   - [Constructors and initialization](#constructors-and-initialization)
     - [Step 1: Defining your settings in a macro](#step-1-defining-your-settings-in-a-macro)
-    - [Step 2: Creating `enum class` and `settings list` (manual)](#step-2-creating-enum-class-and-settings-list-manual)
-    - [Step 2 alternative: Creating `enum class` and `settings list` (automatic)](#step-2-alternative-creating-enum-class-and-settings-list-automatic)
-    - [Example](#example)
+    - [Step 2: Creating `enum class` and `Settings` object (manual)](#step-2-creating-enum-class-and-settings-object-manual)
+    - [Step 2 alternative: Creating `enum class` and `Settings` object (automatic)](#step-2-alternative-creating-enum-class-and-settings-object-automatic)
+    - [Initialization](#initialization)
+    - [Full example](#full-example)
+  - [Settings API](#settings-api)
+    - [Reading and writing values](#reading-and-writing-values)
+    - [Formatting](#formatting)
+    - [Callbacks](#callbacks)
+    - [Type-erased interface (`ISettings`)](#type-erased-interface-isettings)
   - [Setting types](#setting-types)
+  - [Utility functions](#utility-functions)
   - [Important notes](#important-notes)
-    - [Special types](#special-types)
-    - [Migration from v2.x to v3.x](#migration-from-v2x-to-v3x)
+    - [String and ByteStream types](#string-and-bytestream-types)
+    - [Migration from v3 to v4](#migration-from-v3-to-v4)
 - [License](#license)
 
 ---
 
 # Description
 
-Manage your ESP32 device preferences effortlessly with the **SettingsManagerESP32** library. This
-powerful yet user-friendly library abstracts away the complexities of dealing with ESP32
-Non-Volatile Storage, providing you with a seamless and intuitive interface to store and retrieve
-your device settings.
+Manage your ESP32 device settings effortlessly with the **SettingsManagerESP32** library. Built on top of the ESP-IDF NVS API, it provides a clean and type-safe interface to store and retrieve your device settings in non-volatile storage.
 
-Some of the core features are:
+Core features:
 
-- Single place to manage a list of settings in your code.
-- Capable of having a **Key**, **Description Text** (_hint_) and a **Default Value** for each setting. All
-  these values are stored in the stack, no use of the heap.
-- No need to use a key string to access a setting (_default case in the Preferences library_).
-- Use of automatically created enum class to index your settings.
-- Perfect use with a IDE with autocompletion, like VSCode. See example below.
+- Single place to define a group of settings using [X-Macros](https://en.wikipedia.org/wiki/X_macro).
+- Each setting has a **Key**, a **Hint** (description text), and a **Default Value**. All metadata lives in flash - no heap usage.
+- Access settings via a type-safe `enum class` instead of raw key strings.
+- Each `Settings` object owns its own NVS namespace handle, allowing multiple independent groups or shared namespaces.
+- Per-setting and global change callbacks.
+- Full autocompletion support in IDEs like VS Code.
 
 ![floats](.img/floats.png)
 ![strings](.img/strings.png)
@@ -68,7 +72,7 @@ Some of the core features are:
 
 ## Adding library to Arduino IDE
 
-Search for the library in the Library Manager.
+Search for **SettingsManagerESP32** in the Library Manager.
 
 ## Adding library to platformio.ini (PlatformIO)
 
@@ -77,345 +81,434 @@ Search for the library in the Library Manager.
 lib_deps =
   https://github.com/alkonosst/SettingsManagerESP32.git
 
-; Release vx.y.z (using an exact version is recommended)
+; Specific release (recommended for production)
 lib_deps =
-  https://github.com/alkonosst/SettingsManagerESP32.git#v2.0.0
+  https://github.com/alkonosst/SettingsManagerESP32.git#v4.0.0
 ```
 
 ## Using the library
 
 ### Including the library
 
-First, include the library in your file:
-
 ```cpp
 #include "SettingsManagerESP32.h"
-```
-
-By default, there are two definitions which controls the maximum size for **strings** and
-**byte-streams**, which are `SETTINGS_STRING_BUFFER_SIZE` and `SETTINGS_BYTE_STREAM_BUFFER_SIZE`
-respectively, **both set to 32 bytes**. If you need to change these values, you can do it in your code
-before including the library:
-
-```cpp
-#define SETTINGS_STRING_BUFFER_SIZE 64
-#define SETTINGS_BYTE_STREAM_BUFFER_SIZE 64
-#include "SettingsManagerESP32.h"
-```
-
-Or if using PlatformIO, you can add these definitions in your `platformio.ini` file:
-
-```ini
-build_flags =
-  -D SETTINGS_STRING_BUFFER_SIZE=64
-  -D SETTINGS_BYTE_STREAM_BUFFER_SIZE=64
 ```
 
 ### What is inside the library
 
-The library creates a ESP32 `Preferences` object to manage the non-volatile storage named `nvs`. You can use
-this object, if needed, to access the NVS directly:
+All classes and types live in the `NVS` namespace. The main pieces are:
+
+**Classes:**
+
+- `NVS::Settings<T, ENUM, N>` - typed container for a group of NVS settings under a single namespace.
+  - `T` - value type (`bool`, `uint32_t`, `int32_t`, `float`, `double`, `NVS::Str`, `NVS::ByteStream`).
+  - `ENUM` - enum class used to index settings.
+  - `N` - number of settings (use `SETTINGS_COUNT(your_macro)`).
+- `NVS::ISettings` - type-erased interface. Useful for storing heterogeneous `Settings` objects in an array.
+
+**Types:**
+
+| Type                      | Description                                                                                                             |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `NVS::Str`                | Mutable string buffer for `getValue()`. Caller allocates the buffer.                                                    |
+| `NVS::StrView`            | Read-only string view. Used for default values and `setValue()`. Implicitly constructed from `const char*`.             |
+| `NVS::ByteStream`         | Mutable byte buffer for `getValue()`. Caller allocates the buffer.                                                      |
+| `NVS::ByteStreamView`     | Read-only byte view. Used for default values and `setValue()`.                                                          |
+| `NVS::ByteStream::Format` | Metadata enum: `Hex`, `Base64`, `JSONObject`, `JSONArray`. Not persisted in NVS.                                        |
+| `NVS::Type`               | Identifies the value type of a `Settings` object: `Bool`, `UInt32`, `Int32`, `Float`, `Double`, `String`, `ByteStream`. |
+
+**NVS partition lifecycle functions:**
 
 ```cpp
-Preferences nvs;
+NVS::init();   // Initialize the default NVS flash partition. Call once in setup() before any begin().
+NVS::deinit(); // Deinitialize the partition.
+NVS::erase();  // Erase all data in the partition (requires init() again afterwards).
 ```
 
-All the relevant classes and types are inside the `NVS` namespace. The available classes are:
-
-- `Settings<T, ENUM, N>`: Main class to manage settings.
-  - `T` is the type of the setting.
-  - `ENUM` is the enum class to index the settings. The available types are: `bool`, `uint32_t`, `int32_t`, `float`,
-    `double`, `const char*` and `ByteStream`.
-  - `N` is the number of settings in the list. This is automatically calculated by the library using
-    the macro `SETTINGS_COUNT(your_settings_macro)`.
-- `ISettings`: Interface class to manage settings via pointer. You can use this class to create a
-  pointer to a particular `Settings` object.
-
-And the available types are:
-
-- `ByteStream`: Class to manage byte streams. It is used to store raw binary data in the NVS.
-- `Type`: Enum class to define the type of the setting object, which can be `Bool`, `UInt32`, `Int32`,
-  `Float`, `Double`, `String` or `ByteStream`.
+All three accept an optional `const char* partition_name` to target a custom partition.
 
 ## Constructors and initialization
 
-This library makes use of [X-Macros](https://en.wikipedia.org/wiki/X_macro) to make the code
-maintainable and scalable. You can easily add, edit or remove a setting in the same place.
+The library uses [X-Macros](https://en.wikipedia.org/wiki/X_macro) to keep all settings in one place.
 
 ### Step 1: Defining your settings in a macro
 
-In order to create a new group of settings, you need to define a macro with the following structure:
-
 ```cpp
-#define FLOATS(X) \
-  X(SenThr,   "Sensor Voltage Threshold", 3.14,   false) \
-  X(AdcSlope, "ADC Slope Factor",         1.2345, true)  \
-  X(Another,  "Another setting",          0.0,    false)
+#define FLOATS(X)                                \
+  X(SenThr,   "Sensor Threshold", 3.14,   false) \
+  X(AdcSlope, "ADC Slope",        1.2345, true)  \
+  X(Offset,   "ADC Offset",       0.0,    true)
 ```
 
-Structure of the macro:
+Each row defines one setting:
 
-|      | First (key)                                                                                    | Second (hint)                           | Third (default value)                                         | Fourth (formattable)       |     |
-| ---- | ---------------------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------- | -------------------------- | --- |
-| `X(` | Enum class member, also used as a key (**no more than 15 characters** and **no whitespaces**). | Text to describe what the setting does. | Default value. In the example above, a value of type `float`. | Setting formattable or not | `)` |
+| Field         | Description                                                                           |
+| ------------- | ------------------------------------------------------------------------------------- |
+| Name          | Becomes the enum enumerator and the NVS key string. Max 15 characters, no whitespace. |
+| Hint          | Human-readable description.                                                           |
+| Default value | Must match the type of the `Settings` object.                                         |
+| Formattable   | `true` if `formatAll()` should reset this setting to its default.                     |
 
-Each new row is a new setting. All settings in the same macro must be of the same
-type. In the example above all settings are `float`.
+All settings in the same macro must be of the same type.
 
-### Step 2: Creating `enum class` and `settings list` (manual)
-
-Once you have defined your settings, you need to create an `enum class` and a `settings list` object. You must use the
-macros `SETTINGS_EXPAND_ENUM_CLASS` and `SETTINGS_EXPAND_SETTINGS` as argument to your X-Macro
-defined previously, as shown below:
+### Step 2: Creating `enum class` and `Settings` object (manual)
 
 ```cpp
 enum class MyFloats : uint8_t { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<float, MyFloats, SETTINGS_COUNT(FLOATS)> my_floats = { FLOATS(SETTINGS_EXPAND_SETTINGS) };
+NVS::Settings<float, MyFloats, SETTINGS_COUNT(FLOATS)> my_floats("esp32", {FLOATS(SETTINGS_EXPAND_SETTINGS)});
 ```
 
-This automatically will expand to this:
+This expands to:
 
 ```cpp
-enum class MyFloats : uint8_t { SenThr, AdcSlope, Another };
-NVS::Settings<float, MyFloats, 3> my_float = {
-  {"SenThr",   "Sensor Voltage Threshold", 3.14  , true},
-  {"AdcSlope", "ADC Slope Factor",         1.2345, true},
-  {"Another",  "Another setting",          0.0   , true}
-};
+enum class MyFloats : uint8_t { SenThr, AdcSlope, Offset };
+NVS::Settings<float, MyFloats, 3> my_floats("esp32", {
+  {"SenThr",   "Sensor Threshold", 3.14,   false},
+  {"AdcSlope", "ADC Slope",        1.2345, true},
+  {"Offset",   "ADC Offset",       0.0,    true},
+});
 ```
 
-Now you can use the `my_floats` object and the `MyFloats` enum class.
-
-### Step 2 alternative: Creating `enum class` and `settings list` (automatic)
-
-After your macro with settings is defined, you can use the corresponding `SETTINGS_CREATE_XXX`
-macro (_refer to [Setting types](#setting-types) to see all macros_).
-This will create a automatically a `enum class` and a `setting` object to use later.
+### Step 2 alternative: Creating `enum class` and `Settings` object (automatic)
 
 ```cpp
-SETTINGS_CREATE_FLOATS(Floats, FLOATS)
+SETTINGS_CREATE_FLOATS(Floats, "esp32", FLOATS)
 ```
 
-|                           | First                                                             | Second                                    |     |
-| ------------------------- | ----------------------------------------------------------------- | ----------------------------------------- | --- |
-| `SETTINGS_CREATE_FLOATS(` | A name to give to the `enum class` and suffix to `settings list`. | X-Macro with settings defined previously. | `)` |
+| Parameter | Description                                         |
+| --------- | --------------------------------------------------- |
+| `Floats`  | Name for the enum class and the `st_Floats` object. |
+| `"esp32"` | NVS namespace name (max 15 characters).             |
+| `FLOATS`  | X-macro with the settings list.                     |
 
-The compiler will expand the macro to this:
+This creates `enum class Floats` and `NVS::Settings<float, Floats, N> st_Floats(...)`.
+
+### Initialization
+
+Before any read or write, initialize the NVS partition and open each `Settings` handle:
 
 ```cpp
-enum class Floats : uint8_t { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<float, Floats, SETTINGS_COUNT(FLOATS)> st_Floats = { FLOATS(SETTINGS_EXPAND_SETTINGS) };
+void setup() {
+  if (!NVS::init()) {
+    // Handle error
+  }
+
+  if (!st_Floats.begin()) {
+    // Handle error
+  }
+}
 ```
 
-And finally it will expand to this:
+### Full example
 
 ```cpp
-enum class Floats : uint8_t { SenThr, AdcSlope, Another };
-NVS::Settings<float, Floats, 3> st_Floats = {
-  {"SenThr",   "Sensor Voltage Threshold", 3.14  , true},
-  {"AdcSlope", "ADC Slope Factor",         1.2345, true},
-  {"Another",  "Another setting",          0.0   , true}
-};
-```
+#include "SettingsManagerESP32.h"
 
-Now you can use the `st_Floats` object and the `Floats` enum class.
-
-### Example
-
-The following code shows a general example of how to use the library. For more examples, refer to
-the `examples` folder.
-
-```cpp
-// Change the buffer size
-#define SETTINGS_STRING_BUFFER_SIZE 64
-#define SETTINGS_BYTE_STREAM_BUFFER_SIZE 64
-#include "SettingsManagerESP32.h" // Include library
-
-// Step 1: Define the X-Macro.
-// - The macro's name can be whatever you prefer. In this case "UINT32S", because we will store a
-// group of settings of type uint32_t.
 #define UINT32S(X)              \
   X(UInt1, "uint32 1", 1, true) \
   X(UInt2, "uint32 2", 2, true) \
   X(UInt3, "uint32 3", 3, true)
 
-// The argument "X" can be named as you wish, but remember to use it in every row for each new setting.
-#define FLOATS(setting)                 \
-  setting(Float1, "float 1", 1.1, true) \
-  setting(Float2, "float 2", 2.2, true) \
-  setting(Float3, "float 3", 3.3, true)
+#define FLOATS(X)                 \
+  X(Float1, "float 1", 1.1, true) \
+  X(Float2, "float 2", 2.2, true) \
+  X(Float3, "float 3", 3.3, true)
 
-// Step 2: Creating enum class and settings list manually
-enum class Floats { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
-Settings<float, Floats, SETTINGS_COUNT(FLOATS)> float_settings = { FLOATS(SETTINGS_EXPAND_SETTINGS) };
+// Manual creation
+enum class Floats : uint8_t { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
+NVS::Settings<float, Floats, SETTINGS_COUNT(FLOATS)> float_settings("esp32", {FLOATS(SETTINGS_EXPAND_SETTINGS)});
 
-// Step 2 alternative: Creating enum class and settings list automatically
-SETTINGS_CREATE_UINT32S(UInt32s, UINT32S)
+// Automatic creation
+SETTINGS_CREATE_UINT32S(UInt32s, "esp32", UINT32S)
 
 void setup() {
-  // Initialize NVS with namespace "esp32"
-  nvs.begin("esp32");
+  if (!NVS::init()) { /* handle error */ }
+  if (!float_settings.begin()) { /* handle error */ }
+  if (!st_UInt32s.begin()) { /* handle error */ }
 
-  /* Now you could access to the settings methods */
+  // Get the key string: "UInt1"
+  const char* key = st_UInt32s.getKey(UInt32s::UInt1);
 
-  // You should obtain "UInt1"
-  const char* uint32_1_key = UInt32s_list.getKey(UInt32s::UInt1);
+  // Write a value
+  float_settings.setValue(Floats::Float1, 9.99f);
 
-  // You should obtain "Float1"
-  const char* float_1_key  = float_settings.getKey(Floats::Float1);
+  // Read a value
+  float val;
+  if (float_settings.getValue(Floats::Float1, val)) {
+    // val == 9.99f
+  }
 }
+```
+
+## Settings API
+
+### Reading and writing values
+
+```cpp
+// Write
+settings.setValue(MyEnum::Key, value);
+
+// Read - returns true if the key exists in NVS, false if not yet saved
+MyType val;
+bool found = settings.getValue(MyEnum::Key, val);
+
+// Get default value
+auto def = settings.getDefaultValue(MyEnum::Key);
+
+// Get key/hint strings
+const char* key  = settings.getKey(MyEnum::Key);
+const char* hint = settings.getHint(MyEnum::Key);
+```
+
+> [!NOTE]
+> `getValue()` returns `false` when the key has not been saved to NVS yet. In that case, `val` is
+> left **unchanged** - no default value is written to it. Check the return value and fall back to
+> `getDefaultValue()` if needed.
+
+### Formatting
+
+"Formatting" means resetting a setting's NVS value back to its default.
+
+```cpp
+settings.format(MyEnum::Key);        // Reset one setting (respects the formattable flag)
+settings.format(MyEnum::Key, true);  // Reset one setting (ignores the formattable flag)
+settings.formatAll();                // Reset all formattable settings
+settings.formatAll(true);            // Reset all settings regardless of the formattable flag
+```
+
+### Callbacks
+
+Callbacks fire when a value is written via `setValue()` or `format()`.
+
+```cpp
+// Per-setting callback
+// callable_on_format: whether to fire when a format operation writes this setting
+settings.setOnChangeCallback(MyEnum::Key,
+  [](const char* key, MyEnumType setting, MyWriteType value) {
+    // handle change
+  },
+  /*callable_on_format=*/false);
+
+// Global callback (fires for every setting change in this object)
+// The value is passed as const void* - cast to WriteType* before use
+settings.setGlobalOnChangeCallback(
+  [](const char* key, NVS::Type type, size_t index, const void* value) {
+    // handle change
+  },
+  /*callable_on_format=*/true);
+```
+
+For `NVS::Str`, the per-setting callback receives `NVS::StrView`. For `NVS::ByteStream`, it receives `NVS::ByteStreamView`.
+
+### Type-erased interface (`ISettings`)
+
+`NVS::ISettings*` lets you store heterogeneous `Settings` objects in a plain array and operate on them without knowing the value type:
+
+```cpp
+NVS::ISettings* all[] = {&st_Floats, &st_UInt32s, &st_Strings};
+
+for (auto* s : all) {
+  s->begin();
+}
+
+// Access by index
+const char* key = all[0]->getKey(0);
+NVS::Type type  = all[0]->getType();
+
+// Read/write via void*
+float f;
+all[0]->getValuePtr(0, &f, sizeof(f));
+
+float new_val = 1.23f;
+all[0]->setValuePtr(0, &new_val);
 ```
 
 ## Setting types
 
 ```cpp
+// Boolean
 #define BOOLS(X)                     \
   X(Bool1, "boolean 1", false, true) \
-  X(Bool2, "boolean 2", true,  true) \
-  X(Bool3, "boolean 3", false, true)
+  X(Bool2, "boolean 2", true,  true)
 
+SETTINGS_CREATE_BOOLS(Bools, "esp32", BOOLS)
+
+// Unsigned 32-bit integer
 #define UINT32S(X)              \
   X(UInt1, "uint32 1", 1, true) \
-  X(UInt2, "uint32 2", 2, true) \
-  X(UInt3, "uint32 3", 3, true)
+  X(UInt2, "uint32 2", 2, true)
 
-#define INT32S(X)              \
-  X(Int1, "int32 1", -1, true) \
-  X(Int2, "int32 2", -2, true) \
-  X(Int3, "int32 3", -3, true)
+SETTINGS_CREATE_UINT32S(UInt32s, "esp32", UINT32S)
 
+// Signed 32-bit integer
+#define INT32S(X)               \
+  X(Int1, "int32 1", -1, true)  \
+  X(Int2, "int32 2", -2, true)
+
+SETTINGS_CREATE_INT32S(Int32s, "esp32", INT32S)
+
+// Float
 #define FLOATS(X)                 \
   X(Float1, "float 1", 1.1, true) \
-  X(Float2, "float 2", 1.2, true) \
-  X(Float3, "float 3", 1.3, true)
+  X(Float2, "float 2", 2.2, true)
 
-#define DOUBLES(X)                       \
-  X(Double1, "double 1", 1.123456, true) \
-  X(Double2, "double 2", 2.123456, true) \
-  X(Double3, "double 3", 3.123456, true)
+SETTINGS_CREATE_FLOATS(Floats, "esp32", FLOATS)
 
+// Double
+#define DOUBLES(X)                         \
+  X(Double1, "double 1", 1.123456, true)   \
+  X(Double2, "double 2", 2.123456, true)
+
+SETTINGS_CREATE_DOUBLES(Doubles, "esp32", DOUBLES)
+
+// String - default values are StrView, constructed from a string literal
 #define STRINGS(X)                      \
-  X(String1, "string 1", "str 1", true) \
-  X(String2, "string 2", "str 2", true) \
-  X(String3, "string 3", "str 3", true)
+  X(Str1, "string 1", "default 1", true) \
+  X(Str2, "string 2", "default 2", true)
 
-// ByteStream is a special type. It is used to store raw binary data in the NVS.
-const uint8_t byte_default_value[] = {'n', 'v', 's'};
-// ByteStream constructor: (data, size, format)
-// - The data pointer must point to a valid memory location.
-// - Size must match the actual size of the data array.
-// - Format:
-//    - Format can be: Hex, Base64, JSONObject, JSONArray
-//    - The default ByteStream's format is the one that matters. So, when calling getValue(), the format
-//      member will be the one defined in the default value.
-//    - Don't change the value's data format from the one defined in the default value,
-//      because you may never know the actual content of the stored data in NVS based on the format.
-// - IMPORTANT: The ByteStream default value must be declared as const!
-const NVS::ByteStream byte_stream_default = {byte_default_value, 3, NVS::ByteStream::Format::Hex}; // Must be const!
+SETTINGS_CREATE_STRINGS(Strings, "esp32", STRINGS)
 
-#define BYTE_STREAMS(X)                                      \
-  X(ByteStream1, "byte stream 1", byte_stream_default, true) \
-  X(ByteStream2, "byte stream 2", byte_stream_default, true) \
-  X(ByteStream3, "byte stream 3", byte_stream_default, true)
+// ByteStream - default values are ByteStreamView; data must remain valid for the object's lifetime
+const uint8_t bs1_data[]          = {0xDE, 0xAD, 0xBE, 0xEF};
+const NVS::ByteStreamView bs1_def = {bs1_data, sizeof(bs1_data), NVS::ByteStream::Format::Hex};
 
-// Automatic creation
-SETTINGS_CREATE_BOOLS(Bools, BOOLS)       // Boolean
-SETTINGS_CREATE_UINT32S(UInt32s, UINT32S) // Unsigned 32 bit integer
-SETTINGS_CREATE_INT32S(Int32s, INT32S)    // Signed 32 bit integer
-SETTINGS_CREATE_FLOATS(Floats, FLOATS)    // Floating-point
-SETTINGS_CREATE_DOUBLES(Doubles, DOUBLES) // Double precision floating-point
-SETTINGS_CREATE_STRINGS(Strings, STRINGS) // String, array of characters
-SETTINGS_CREATE_BYTE_STREAMS(ByteStreams, BYTE_STREAMS) // Byte stream
+const uint8_t bs2_data[]          = {0x01, 0x02, 0x03, 0x04};
+const NVS::ByteStreamView bs2_def = {bs2_data, sizeof(bs2_data), NVS::ByteStream::Format::Hex};
+
+#define BYTESTREAMS(X)                       \
+  X(BS1, "byte stream 1", bs1_def, true)     \
+  X(BS2, "byte stream 2", bs2_def, true)
+
+SETTINGS_CREATE_BYTE_STREAMS(ByteStreams, "esp32", BYTESTREAMS)
 ```
 
-## Important notes
+## Utility functions
 
-### Special types
-
-The `string` and `byte stream` types are special. When reading a value of these types using
-`getValue()`, **you need to give a mutex using the** `giveMutex()` **method after you are done using the
-value**, like this:
+All utility functions are in the `NVS` namespace.
 
 ```cpp
-// Get the value of the setting
-const char* str_value = strings.getValue(Strings::String_1);
+// Convert a Type enum to a string ("Bool", "Float", "String", etc.)
+const char* NVS::typeToStr(NVS::Type t);
 
-// Do something with the value
-// ...
+// Convert a ByteStream::Format enum to a string ("Hex", "Base64", etc.)
+const char* NVS::formatToStr(NVS::ByteStream::Format f);
 
-// Give the mutex back to the library
-strings.giveMutex();
+// Calculate the buffer size needed to hold the hex string for byte_count bytes
+// Without spaces: "DEADBEEF\0"  → hexStrSize(4)       = 9
+// With spaces:    "DE AD BE EF\0" → hexStrSize(4, true) = 12
+constexpr size_t NVS::hexStrSize(size_t byte_count, bool with_spaces = false);
+
+// Encode a ByteStreamView to a hex string
+// buf must hold at least hexStrSize(bs.size, with_spaces) bytes
+bool NVS::fromHexToStr(NVS::ByteStreamView bs, char* buf, size_t buf_size, bool with_spaces = false);
+
+// Decode a hex string into a ByteStream buffer; out.size is updated on success
+bool NVS::fromStrToHex(const char* hex, NVS::ByteStream& out, bool with_spaces = false);
 ```
-
-This is because the library creates a static buffer to store the value, and this buffer is shared
-between all settings of the same object to save space in the RAM. This is not a problem for the
-other types.
-
-The `ByteStream` type has an special member called `format`, which indicates the format of the data
-stored in the byte stream. It is optional to use. The available formats are:
-
-- `Hex`: Data is stored as hexadecimal string.
-- `Base64`: Data is stored as Base64 encoded string.
-- `JSONObject`: Data is stored as JSON object string.
-- `JSONArray`: Data is stored as JSON array string.
-
-When creating a `ByteStream` setting, you must define the format in the default value. When reading
-the value using `getValue()`, the format will be the one defined in the default value. You can use
-this format to know how to interpret the data stored in the byte stream.
-
-```cpp
-const uint8_t my_data[] = {0xDE, 0xAD, 0xBE, 0xEF};
-
-const NVS::ByteStream bs_default = {
-  my_data,
-  sizeof(my_data),
-  NVS::ByteStream::Format::Hex
-};
-
-#define BYTESTREAMS(X)                          \
-  X(BS_1, "My ByteStream 1", bs_default, false) \
-```
-
-> [!IMPORTANT]
-> The `ByteStream` default value must be declared as `const`, because the library uses it as a constant
-> reference to know the size and format of the data. If not declared as `const`, the compiler may throw
-> an error. Example:
->
-> ```cpp
-> const NVS::ByteStream bs_default = { ... }; // Correct
-> NVS::ByteStream bs_default = { ... };       // Incorrect
-> ```
->
-> Also, if you are using the `Format` member, make sure that the data you are storing in the
-> ByteStream matches the format defined in the default value. Otherwise, you may get unexpected results
-> when reading the value.
-
-### Migration from v2.x to v3.x
-
-There is a breaking change in the library from v2.x to v3.x. The `Settings` now has 3 template
-parameters. The third one is the number of settings in the list:
-
-- Manual creation: You must use the macro `SETTINGS_COUNT()` to get the number of settings in the list.
-- Automatic creation: No changes needed.
 
 Example:
 
 ```cpp
-#define FLOATS(X) \
-  // ...
+uint8_t buf[32];
+NVS::ByteStream value{buf, sizeof(buf)};
+bytestreams.getValue(ByteStreams::BS1, value);
 
-enum class MyFloats : uint8_t { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
+char hex_compact[NVS::hexStrSize(32)];
+char hex_spaced[NVS::hexStrSize(32, true)];
+NVS::fromHexToStr(value, hex_compact, sizeof(hex_compact));          // "DEADBEEF"
+NVS::fromHexToStr(value, hex_spaced,  sizeof(hex_spaced),  true);   // "DE AD BE EF"
 
-// Old way (v2.x)
-Settings<float, MyFloats> my_floats = { FLOATS(SETTINGS_EXPAND_SETTINGS) };
-
-// New way (v3.x)
-Settings<float, MyFloats, SETTINGS_COUNT(FLOATS)> my_floats = { FLOATS(SETTINGS_EXPAND_SETTINGS) };
+// Decode back
+NVS::ByteStream decoded{buf, sizeof(buf)};
+NVS::fromStrToHex("CAFEBABE", decoded);
+NVS::fromStrToHex("CA FE BA BE", decoded, true);
 ```
 
-This change was made because the **Arduino core v3** makes the `std::initializer_list` member of the
-`Settings` class with undefined behavior. Now the library uses a fixed size `std::array` to store
-the settings list, which is much safer.
+## Important notes
+
+### String and ByteStream types
+
+`NVS::Str` and `NVS::ByteStream` require the **caller to provide a buffer** before calling `getValue()`. The library writes directly into that buffer - no heap allocation, no shared internal buffer, and no mutex needed.
+
+**Strings:**
+
+```cpp
+// Default values use StrView - implicitly constructed from const char*
+// No extra declaration needed in the macro
+
+// Reading a string value
+char buf[64];
+NVS::Str out{buf, sizeof(buf)};
+if (strings.getValue(Strings::Str1, out)) {
+  Serial.println(out.data);
+}
+
+// Writing a string value (StrView is constructed implicitly)
+strings.setValue(Strings::Str1, "new value");
+
+// Getting the default value
+NVS::StrView def = strings.getDefaultValue(Strings::Str1);
+Serial.println(def.data);
+```
+
+**ByteStreams:**
+
+```cpp
+// Default values - must declare ByteStreamView (data pointer must outlive the Settings object)
+const uint8_t my_data[]          = {0xDE, 0xAD, 0xBE, 0xEF};
+const NVS::ByteStreamView my_def = {my_data, sizeof(my_data), NVS::ByteStream::Format::Hex};
+
+// Reading a ByteStream value
+uint8_t buf[32];
+NVS::ByteStream out{buf, sizeof(buf)};
+if (bytestreams.getValue(ByteStreams::BS1, out)) {
+  // out.data contains the bytes, out.size is the number of bytes read
+}
+
+// Writing a ByteStream value (ByteStreamView)
+const uint8_t new_data[]             = {0xCA, 0xFE, 0xBA, 0xBE};
+const NVS::ByteStreamView new_value  = {new_data, sizeof(new_data), NVS::ByteStream::Format::Hex};
+bytestreams.setValue(ByteStreams::BS1, new_value);
+
+// Or use the implicit conversion from ByteStream to ByteStreamView
+NVS::ByteStream writable{buf, sizeof(buf)};
+// ... fill buf ...
+bytestreams.setValue(ByteStreams::BS1, writable); // implicit conversion
+```
+
+> [!NOTE]
+> The `ByteStream::Format` field is metadata only - it is **not persisted in NVS**. Use it as a
+> hint to know how to interpret the raw bytes when displaying or transmitting them.
+
+### Migration from v3 to v4
+
+The previous v3 release can be found at [v3.1.0](https://github.com/alkonosst/SettingsManagerESP32/tree/v3.1.0).
+
+v4 is a full rewrite with several breaking changes:
+
+| Area                         | v3                         | v4                                                 |
+| ---------------------------- | -------------------------- | -------------------------------------------------- |
+| NVS backend                  | Arduino `Preferences`      | ESP-IDF `nvs.h`                                    |
+| Global NVS object            | `Preferences nvs` (global) | `NVS::init()` / `NVS::deinit()`                    |
+| Handle lifecycle             | `nvs.begin("ns")` (global) | `settings.begin()` per object                      |
+| Namespace                    | Shared single namespace    | Each `Settings` object owns its namespace          |
+| `SETTINGS_CREATE_XXX` params | `(name, macro)`            | `(name, ns, macro)`                                |
+| String type                  | `const char*`              | `NVS::Str` (read) / `NVS::StrView` (write/default) |
+| ByteStream default           | `const NVS::ByteStream`    | `const NVS::ByteStreamView`                        |
+| `getValue()` on miss         | Wrote default to out-param | Leaves out-param **unchanged**, returns `false`    |
+| Mutex for strings            | `giveMutex()` required     | Not needed - caller provides the buffer            |
+| Shared internal buffer       | Yes (strings/bytestreams)  | No - caller-owned buffers throughout               |
+
+**Minimal migration steps:**
+
+1. Replace `nvs.begin("ns")` with `NVS::init()` + `settings.begin()`.
+2. Add the namespace string as the second parameter to all `SETTINGS_CREATE_XXX` calls.
+3. Change string default values from `"str"` to `NVS::StrView{"str"}` (or keep the string literal - it converts implicitly).
+4. Change ByteStream default values from `const NVS::ByteStream{...}` to `const NVS::ByteStreamView{...}`.
+5. Change string read variables from `const char*` to `NVS::Str{buf, sizeof(buf)}` with a caller-owned buffer.
+6. Change bytestream read variables to `NVS::ByteStream{buf, sizeof(buf)}` with a caller-owned buffer.
+7. Remove all `giveMutex()` calls.
+8. If you relied on `getValue()` filling `out` with the default on a miss, add an explicit fallback.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
   - [Setting types](#setting-types)
   - [Utility functions](#utility-functions)
   - [Important notes](#important-notes)
+    - [Closing handles before erasing the partition](#closing-handles-before-erasing-the-partition)
     - [String and ByteStream types](#string-and-bytestream-types)
     - [Migration from v3 to v4](#migration-from-v3-to-v4)
 - [License](#license)
@@ -126,6 +127,11 @@ NVS::erase();  // Erase all data in the partition (requires init() again afterwa
 ```
 
 All three accept an optional `const char* partition_name` to target a custom partition.
+
+> [!IMPORTANT]
+> Call `end()` on every open `Settings` object **before** calling `NVS::erase()`. Erasing the
+> partition implicitly deinitializes it; any handle that is still open will be left in an invalid
+> state and subsequent reads/writes will fail silently.
 
 ## Constructors and initialization
 
@@ -252,6 +258,11 @@ settings.setValue(MyEnum::Key, value);
 MyType val;
 bool found = settings.getValue(MyEnum::Key, val);
 
+// Read with automatic fallback to the default value
+// Returns the NVS value if the key exists, or the default value if not saved or on error.
+// In both cases `val` is updated to match the returned value.
+MyType result = settings.getValueOrDefault(MyEnum::Key, val);
+
 // Get default value
 auto def = settings.getDefaultValue(MyEnum::Key);
 
@@ -263,7 +274,7 @@ const char* hint = settings.getHint(MyEnum::Key);
 > [!NOTE]
 > `getValue()` returns `false` when the key has not been saved to NVS yet. In that case, `val` is
 > left **unchanged** - no default value is written to it. Check the return value and fall back to
-> `getDefaultValue()` if needed.
+> `getDefaultValue()` if needed, or use `getValueOrDefault()` to get the fallback automatically.
 
 ### Formatting
 
@@ -318,6 +329,13 @@ NVS::Type type  = all[0]->getType();
 // Read/write via void*
 float f;
 all[0]->getValuePtr(0, &f, sizeof(f));
+
+// Read with fallback via void* - returns a non-null pointer to the result (NVS or default)
+// The result is always written into the provided buffer; cast the returned pointer to use it.
+const void* result = all[0]->getValuePtrOrDefault(0, &f, sizeof(f));
+if (result) {
+  float val = *static_cast<const float*>(result);
+}
 
 float new_val = 1.23f;
 all[0]->setValuePtr(0, &new_val);
@@ -387,6 +405,16 @@ SETTINGS_CREATE_BYTE_STREAMS(ByteStreams, "esp32", BYTESTREAMS)
 All utility functions are in the `NVS` namespace.
 
 ```cpp
+// Get NVS storage statistics for the default (or a custom) partition
+nvs_stats_t stats;
+if (NVS::getStats(stats)) {
+  Serial.printf("Used entries     : %u\n", stats.used_entries);
+  Serial.printf("Free entries     : %u\n", stats.free_entries);
+  Serial.printf("Available entries: %u\n", stats.available_entries);
+  Serial.printf("Total entries    : %u\n", stats.total_entries);
+  Serial.printf("Namespaces       : %u\n", stats.namespace_count);
+}
+
 // Convert a Type enum to a string ("Bool", "Float", "String", etc.)
 const char* NVS::typeToStr(NVS::Type t);
 
@@ -394,8 +422,8 @@ const char* NVS::typeToStr(NVS::Type t);
 const char* NVS::formatToStr(NVS::ByteStream::Format f);
 
 // Calculate the buffer size needed to hold the hex string for byte_count bytes
-// Without spaces: "DEADBEEF\0"  → hexStrSize(4)       = 9
-// With spaces:    "DE AD BE EF\0" → hexStrSize(4, true) = 12
+// Without spaces: "DEADBEEF\0"    -> hexStrSize(4)       = 9
+// With spaces:    "DE AD BE EF\0" -> hexStrSize(4, true) = 12
 constexpr size_t NVS::hexStrSize(size_t byte_count, bool with_spaces = false);
 
 // Encode a ByteStreamView to a hex string
@@ -425,6 +453,26 @@ NVS::fromStrToHex("CA FE BA BE", decoded, true);
 ```
 
 ## Important notes
+
+### Closing handles before erasing the partition
+
+`NVS::erase()` erases the entire partition and **implicitly deinitializes it**. Any`Settings` handle that is still open at that point is left dangling: subsequent reads and writes on it will fail or produce undefined behaviour.
+
+The correct sequence is:
+
+```cpp
+// 1. Close all open handles
+st_Floats.end();
+st_UInt32s.end();
+
+// 2. Erase
+NVS::erase();
+
+// 3. Re-initialize and re-open
+NVS::init();
+st_Floats.begin();
+st_UInt32s.begin();
+```
 
 ### String and ByteStream types
 

--- a/README.md
+++ b/README.md
@@ -330,11 +330,11 @@ NVS::Type type  = all[0]->getType();
 float f;
 all[0]->getValuePtr(0, &f, sizeof(f));
 
-// Read with fallback via void* - returns a non-null pointer to the result (NVS or default)
-// The result is always written into the provided buffer; cast the returned pointer to use it.
-const void* result = all[0]->getValuePtrOrDefault(0, &f, sizeof(f));
-if (result) {
-  float val = *static_cast<const float*>(result);
+// Read with fallback via void* - returns true if successful (NVS value or default written to buffer)
+// Returns false on index out of bounds or buffer too small. The value is always in f on true.
+bool ok = all[0]->getValuePtrOrDefault(0, &f, sizeof(f));
+if (ok) {
+  // f holds the NVS value, or the default if the key was not found
 }
 
 float new_val = 1.23f;

--- a/examples/Booleans/Booleans.ino
+++ b/examples/Booleans/Booleans.ino
@@ -5,12 +5,12 @@
  */
 
 /** Explanation of the example:
- * - Three settings are created, all with formattable values.
+ * - Three boolean settings are created, all with formattable values.
  * - The loop function reads the serial input and performs the following actions:
  *  - '.' restarts the ESP32.
  *  - 'p' prints all settings, including key, hint, default value, and current value.
- *  - 's' sets new values for each setting.
- *  - '1' sets a new value only for the first setting.
+ *  - 's' sets each setting to a random boolean value.
+ *  - '1' toggles the first setting.
  *  - 'f' formats all settings to their default values.
  */
 
@@ -18,18 +18,17 @@
 
 #include "SettingsManagerESP32.h"
 
-// Integers, all formattable
-#define UINTS(X)               \
-  X(UInt_1, "UInt 1", 1, true) \
-  X(UInt_2, "UInt 2", 2, true) \
-  X(UInt_3, "UInt 3", 3, true)
+// Booleans, all formattable
+#define BOOLS(X)                   \
+  X(Flag_1, "Flag 1", false, true) \
+  X(Flag_2, "Flag 2", true, true)  \
+  X(Flag_3, "Flag 3", false, true)
 
-// Enum for integer settings
-enum class UInts : uint8_t { UINTS(SETTINGS_EXPAND_ENUM_CLASS) };
+// Enum for boolean settings
+enum class Bools : uint8_t { BOOLS(SETTINGS_EXPAND_ENUM_CLASS) };
 
-// Settings object for integers, namespace "esp32"
-NVS::Settings<uint32_t, UInts, SETTINGS_COUNT(UINTS)> uints("esp32",
-                                                            {UINTS(SETTINGS_EXPAND_SETTINGS)});
+// Settings object for booleans, namespace "esp32"
+NVS::Settings<bool, Bools, SETTINGS_COUNT(BOOLS)> bools("esp32", {BOOLS(SETTINGS_EXPAND_SETTINGS)});
 
 void setup() {
   Serial.begin(115200);
@@ -43,7 +42,7 @@ void setup() {
       delay(1000);
   }
 
-  if (!uints.begin()) {
+  if (!bools.begin()) {
     Serial.println("Failed to open settings handle!");
     while (true)
       delay(1000);
@@ -72,18 +71,18 @@ void loop() {
       Serial.println("List of settings:");
       Serial.printf("%-10s%-10s%-10s%-10s\n", "Key", "Hint", "Default", "Value");
 
-      for (size_t i = 0; i < uints.getSize(); i++) {
-        Serial.printf("%-10s", uints.getKey(static_cast<UInts>(i)));
-        Serial.printf("%-10s", uints.getHint(static_cast<UInts>(i)));
-        Serial.printf("%-10" PRIu32, uints.getDefaultValue(static_cast<UInts>(i)));
+      for (size_t i = 0; i < bools.getSize(); i++) {
+        Serial.printf("%-10s", bools.getKey(static_cast<Bools>(i)));
+        Serial.printf("%-10s", bools.getHint(static_cast<Bools>(i)));
+        Serial.printf("%-10s", bools.getDefaultValue(static_cast<Bools>(i)) ? "true" : "false");
 
-        uint32_t val;
-        if (!uints.getValue(static_cast<UInts>(i), val)) {
+        bool val;
+        if (!bools.getValue(static_cast<Bools>(i), val)) {
           Serial.printf("%-10s\n", "Error!");
           continue;
         }
 
-        Serial.printf("%-10" PRIu32 "\n", val);
+        Serial.printf("%-10s\n", val ? "true" : "false");
       }
 
       Serial.println();
@@ -94,12 +93,12 @@ void loop() {
     {
       Serial.println("Setting new values...");
 
-      for (size_t i = 0; i < uints.getSize(); i++) {
-        const char* key    = uints.getKey(static_cast<UInts>(i));
-        uint32_t new_value = random(0, 100);
+      for (size_t i = 0; i < bools.getSize(); i++) {
+        const char* key = bools.getKey(static_cast<Bools>(i));
+        bool new_value  = random(0, 2);
 
-        if (uints.setValue(static_cast<UInts>(i), new_value)) {
-          Serial.printf("- Set %s to %" PRIu32 "\n", key, new_value);
+        if (bools.setValue(static_cast<Bools>(i), new_value)) {
+          Serial.printf("- Set %s to %s\n", key, new_value ? "true" : "false");
         } else {
           Serial.printf("- Failed to set value for %s\n", key);
         }
@@ -111,15 +110,20 @@ void loop() {
     // Modify only the first setting, leaving the others unchanged
     case '1':
     {
-      Serial.println("Modifying first setting...");
+      Serial.println("Toggling first setting...");
 
-      const char* key    = uints.getKey(UInts::UInt_1);
-      uint32_t new_value = random(0, 100);
+      bool current;
+      if (!bools.getValue(Bools::Flag_1, current)) {
+        Serial.println("- Failed to read Flag_1");
+        break;
+      }
 
-      if (uints.setValue(UInts::UInt_1, new_value)) {
-        Serial.printf("- Set %s to %" PRIu32 "\n", key, new_value);
+      bool toggled = !current;
+      if (bools.setValue(Bools::Flag_1, toggled)) {
+        Serial.printf(
+          "- Flag_1: %s -> %s\n", current ? "true" : "false", toggled ? "true" : "false");
       } else {
-        Serial.printf("- Failed to set value for %s\n", key);
+        Serial.println("- Failed to set Flag_1");
       }
 
       Serial.println();
@@ -130,7 +134,7 @@ void loop() {
     {
       Serial.print("Formatting settings... ");
 
-      uint8_t errors = uints.formatAll();
+      uint8_t errors = bools.formatAll();
 
       if (errors == 0) {
         Serial.println("done.\n");

--- a/examples/Bytestreams/Bytestreams.ino
+++ b/examples/Bytestreams/Bytestreams.ino
@@ -1,92 +1,80 @@
 /**
- * SPDX-FileCopyrightText: 2025 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
 
 /** Explanation of the example:
- * - Three settings are created, all with formattable values.
+ * - Three ByteStream settings are created, all with formattable values.
+ * - Each setting stores a binary blob tagged with a format hint (Hex, Base64, JSONObject).
+ *   The format tag is metadata only - it is not persisted in NVS.
  * - The loop function reads the serial input and performs the following actions:
  *  - '.' restarts the ESP32.
- *  - 'p' prints all settings, including key, hint, default value, and current value.
+ *  - 'p' prints all settings, including key, hint, format, default value, and current value.
  *  - 's' sets new values for each setting.
+ *  - '1' sets a new value only for the first setting.
  *  - 'f' formats all settings to their default values.
  */
 
+#include <Arduino.h>
+
 #include "SettingsManagerESP32.h"
 
-// Example of Bytestream values with string data (size includes null terminator)
+// Default values (read-only views - data lives in flash)
+// Each blob ends with a null byte so it can be printed as a C-string.
+const uint8_t bs1_data[]          = {'A', 'A', 'A', '\0'};
+const NVS::ByteStreamView bs1_def = {bs1_data, sizeof(bs1_data), NVS::ByteStream::Format::Hex};
 
-// Default values
-// - Format options: Hex, Base64, JSONObject, JSONArray
-// - Each one has a null terminator included in the size for easier printing
-const uint8_t bs1_default_data[]  = {0x31, 0x31, 0x31, 0x00}; // "111"
-const NVS::ByteStream bs1_default = {
-  bs1_default_data, sizeof(bs1_default_data), NVS::ByteStream::Format::Hex};
+const uint8_t bs2_data[]          = {'B', 'B', 'B', '\0'};
+const NVS::ByteStreamView bs2_def = {bs2_data, sizeof(bs2_data), NVS::ByteStream::Format::Base64};
 
-const char bs2_default_data[]     = "MTEx"; // "111" in Base64
-const NVS::ByteStream bs2_default = {reinterpret_cast<const uint8_t*>(bs2_default_data),
-                                     sizeof(bs2_default_data),
-                                     NVS::ByteStream::Format::Base64};
+const uint8_t bs3_data[]          = {'C', 'C', 'C', '\0'};
+const NVS::ByteStreamView bs3_def = {
+  bs3_data, sizeof(bs3_data), NVS::ByteStream::Format::JSONObject};
 
-const char bs3_default_data[]     = "{\"value\": 111}";
-const NVS::ByteStream bs3_default = {reinterpret_cast<const uint8_t*>(bs3_default_data),
-                                     sizeof(bs3_default_data),
-                                     NVS::ByteStream::Format::JSONObject};
+// ByteStreams, all formattable
+#define BYTESTREAMS(X)           \
+  X(BS_1, "bs 1", bs1_def, true) \
+  X(BS_2, "bs 2", bs2_def, true) \
+  X(BS_3, "bs 3", bs3_def, true)
 
-// New values
-const uint8_t bs1_new_data[]  = {0x32, 0x32, 0x32, 0x00}; // "222"
-const NVS::ByteStream bs1_new = {reinterpret_cast<const uint8_t*>(bs1_new_data),
-                                 sizeof(bs1_new_data),
-                                 NVS::ByteStream::Format::Hex};
-
-const char bs2_new_data[]     = "MjIy"; // "222" in Base64
-const NVS::ByteStream bs2_new = {reinterpret_cast<const uint8_t*>(bs2_new_data),
-                                 sizeof(bs2_new_data),
-                                 NVS::ByteStream::Format::Base64};
-
-const char bs3_new_data[]     = "{\"value\": 222}";
-const NVS::ByteStream bs3_new = {reinterpret_cast<const uint8_t*>(bs3_new_data),
-                                 sizeof(bs3_new_data),
-                                 NVS::ByteStream::Format::JSONObject};
-
-const NVS::ByteStream* bs_new_values[] = {&bs1_new, &bs2_new, &bs3_new};
-
-// Bytestreams, all formattable
-#define BYTESTREAMS(X)               \
-  X(BS_1, "bs 1", bs1_default, true) \
-  X(BS_2, "bs 2", bs2_default, true) \
-  X(BS_3, "bs 3", bs3_default, true)
-
+// Enum for ByteStream settings
 enum class ByteStreams : uint8_t { BYTESTREAMS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<NVS::ByteStream, ByteStreams, SETTINGS_COUNT(BYTESTREAMS)> bs = {
-  BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)};
 
-const char* bytestreamFormatToString(NVS::ByteStream::Format format) {
-  switch (format) {
-    case NVS::ByteStream::Format::Hex: return "Hex";
-    case NVS::ByteStream::Format::Base64: return "Base64";
-    case NVS::ByteStream::Format::JSONObject: return "JsonObject";
-    case NVS::ByteStream::Format::JSONArray: return "JsonArray";
-    default: return "Unknown";
-  }
-}
+// Settings object for ByteStreams, namespace "esp32"
+NVS::Settings<NVS::ByteStream, ByteStreams, SETTINGS_COUNT(BYTESTREAMS)>
+  bs("esp32", {BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)});
 
 void setup() {
   Serial.begin(115200);
+  delay(2000);
+
   Serial.println("Starting...");
 
-  // Initialize NVS namespace
-  nvs.begin("esp32");
+  if (!NVS::init()) {
+    Serial.println("Failed to initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!bs.begin()) {
+    Serial.println("Failed to open settings handle!");
+    while (true)
+      delay(1000);
+  }
 }
 
 void loop() {
-  // Read serial input
-  if (!Serial.available()) {
-    return;
-  }
+  if (!Serial.available()) return;
 
   char c = Serial.read();
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    Serial.println(">");
+  } else {
+    Serial.printf("> %c\r\n", c);
+  }
 
   switch (c) {
     // Restart ESP32
@@ -96,25 +84,30 @@ void loop() {
     case 'p':
     {
       Serial.println("List of settings:");
+      Serial.printf("%-8s%-8s%-12s%-12s%-12s\n", "Key", "Hint", "Format", "Default", "Value");
+
+      static uint8_t buf[64];
 
       for (size_t i = 0; i < bs.getSize(); i++) {
-        Serial.println("-------------------------");
-        Serial.printf("ByteStream %u:\n", i + 1);
-        Serial.printf("- Key: %s\n", bs.getKey(static_cast<ByteStreams>(i)));
-        Serial.printf("- Hint: %s\n", bs.getHint(static_cast<ByteStreams>(i)));
+        NVS::ByteStreamView def = bs.getDefaultValue(static_cast<ByteStreams>(i));
 
-        NVS::ByteStream def_value = bs.getDefaultValue(static_cast<ByteStreams>(i));
-        Serial.printf("- Format: %s\n", bytestreamFormatToString(def_value.format));
-        Serial.printf("- Default value: %s (%u)\n", def_value.data, def_value.size);
+        // Initialize the read buffer with the format tag from the default value
+        NVS::ByteStream value{buf, sizeof(buf), def.format};
 
-        NVS::ByteStream value = bs.getValue(static_cast<ByteStreams>(i));
-        Serial.printf("- Current value: %s (%u)\n", value.data, value.size);
+        Serial.printf("%-8s", bs.getKey(static_cast<ByteStreams>(i)));
+        Serial.printf("%-8s", bs.getHint(static_cast<ByteStreams>(i)));
+        Serial.printf("%-12s", NVS::formatToStr(def.format));
+        Serial.printf("%-12s", reinterpret_cast<const char*>(def.data));
 
-        // IMPORTANT: release the mutex when done using a value
-        bs.giveMutex();
+        if (!bs.getValue(static_cast<ByteStreams>(i), value)) {
+          Serial.printf("%-12s\n", "Error!");
+          continue;
+        }
+
+        Serial.printf("%-12s\n", reinterpret_cast<const char*>(value.data));
       }
 
-      Serial.println("-------------------------");
+      Serial.println();
     } break;
 
     // Set new values for each setting
@@ -122,14 +115,40 @@ void loop() {
     {
       Serial.println("Setting new values...");
 
+      static const uint8_t new1[]                 = {'X', 'X', 'X', '\0'};
+      static const uint8_t new2[]                 = {'Y', 'Y', 'Y', '\0'};
+      static const uint8_t new3[]                 = {'Z', 'Z', 'Z', '\0'};
+      static const NVS::ByteStreamView new_vals[] = {
+        {new1, sizeof(new1)},
+        {new2, sizeof(new2)},
+        {new3, sizeof(new3)},
+      };
+
       for (size_t i = 0; i < bs.getSize(); i++) {
         const char* key = bs.getKey(static_cast<ByteStreams>(i));
 
-        if (bs.setValue(static_cast<ByteStreams>(i), *bs_new_values[i])) {
-          Serial.printf("- Set %s to %s\n", key, bs_new_values[i]->data);
+        if (bs.setValue(static_cast<ByteStreams>(i), new_vals[i])) {
+          Serial.printf("- Set %s to %s\n", key, reinterpret_cast<const char*>(new_vals[i].data));
         } else {
           Serial.printf("- Failed to set value for %s\n", key);
         }
+      }
+
+      Serial.println();
+    } break;
+
+    // Modify only the first setting, leaving the others unchanged
+    case '1':
+    {
+      Serial.println("Modifying first setting...");
+
+      static const uint8_t payload[]           = {'1', '2', '3', '4', '\0'};
+      static const NVS::ByteStreamView new_val = {payload, sizeof(payload)};
+
+      if (bs.setValue(ByteStreams::BS_1, new_val)) {
+        Serial.printf("- Set BS_1 to %s\n", reinterpret_cast<const char*>(new_val.data));
+      } else {
+        Serial.println("- Failed to set BS_1");
       }
 
       Serial.println();
@@ -147,39 +166,6 @@ void loop() {
       } else {
         Serial.printf("failed with %u errors!\n\n", errors);
       }
-    } break;
-
-    // Print Bytestream 1 (hex format)
-    case '1':
-    {
-      NVS::ByteStream value = bs.getValue(ByteStreams::BS_1);
-      Serial.printf("Bytestream 1 (%s): %s (%u)\n\n",
-                    bytestreamFormatToString(value.format),
-                    value.data,
-                    value.size);
-      bs.giveMutex();
-    } break;
-
-    // Print Bytestream 2 (base64 format)
-    case '2':
-    {
-      NVS::ByteStream value = bs.getValue(ByteStreams::BS_2);
-      Serial.printf("Bytestream 2 (%s): %s (%u)\n\n",
-                    bytestreamFormatToString(value.format),
-                    value.data,
-                    value.size);
-      bs.giveMutex();
-    } break;
-
-    // Print Bytestream 3 (JSON object format)
-    case '3':
-    {
-      NVS::ByteStream value = bs.getValue(ByteStreams::BS_3);
-      Serial.printf("Bytestream 3 (%s): %s (%u)\n\n",
-                    bytestreamFormatToString(value.format),
-                    value.data,
-                    value.size);
-      bs.giveMutex();
     } break;
   }
 }

--- a/examples/Callbacks/Callbacks.ino
+++ b/examples/Callbacks/Callbacks.ino
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** Explanation of the example:
+ * - Three uint32_t settings are created, all formattable.
+ * - onChange callbacks are registered at two levels:
+ *   - A global callback that fires on setValue for all settings (not on format).
+ *   - A per-setting callback for Counter_1 that does NOT fire on format.
+ *   - A per-setting callback for Counter_2 that DOES fire on format.
+ * - The loop function reads the serial input and performs the following actions:
+ *  - '.' restarts the ESP32.
+ *  - 'p' prints the current value of each setting.
+ *  - 's' sets all settings to random values — all callbacks fire.
+ *  - 'f' formats all settings to their default values — only Counter_2's callback fires.
+ */
+
+#include <Arduino.h>
+
+#include "SettingsManagerESP32.h"
+
+// Counters, all formattable
+#define COUNTERS(X)                  \
+  X(Counter_1, "Counter 1", 0, true) \
+  X(Counter_2, "Counter 2", 0, true) \
+  X(Counter_3, "Counter 3", 0, true)
+
+// Enum for counter settings
+enum class Counters : uint8_t { COUNTERS(SETTINGS_EXPAND_ENUM_CLASS) };
+
+// Settings object for counters, namespace "esp32"
+NVS::Settings<uint32_t, Counters, SETTINGS_COUNT(COUNTERS)>
+  counters("esp32", {COUNTERS(SETTINGS_EXPAND_SETTINGS)});
+
+// Per-setting callback for Counter_1. Registered with callable_on_format=false, so it only fires
+// when setValue() is called directly.
+void onCounter1Change(const char* key, const Counters setting, const uint32_t value) {
+  Serial.printf("  [Counter_1] %s = %" PRIu32 "\n", key, value);
+}
+
+// Per-setting callback for Counter_2. Registered with callable_on_format=true, so it fires on
+// both setValue() and format operations.
+void onCounter2Change(const char* key, const Counters setting, const uint32_t value) {
+  Serial.printf("  [Counter_2] %s = %" PRIu32 "\n", key, value);
+}
+
+// Global callback. Fires for any setting when setValue() is called (callable_on_format=false).
+void onAnyChange(const char* key, const NVS::Type type, const size_t index, const void* value) {
+  Serial.printf("  [global] index=%u, key=%s, value=%" PRIu32 "\n",
+                index,
+                key,
+                *static_cast<const uint32_t*>(value));
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(2000);
+
+  Serial.println("Starting...");
+
+  if (!NVS::init()) {
+    Serial.println("Failed to initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!counters.begin()) {
+    Serial.println("Failed to open settings handle!");
+    while (true)
+      delay(1000);
+  }
+
+  // Global callback: fires on setValue, silent during format
+  counters.setGlobalOnChangeCallback(onAnyChange, false);
+
+  // Counter_1: fires on setValue only
+  counters.setOnChangeCallback(Counters::Counter_1, onCounter1Change, false);
+
+  // Counter_2: fires on setValue AND format
+  counters.setOnChangeCallback(Counters::Counter_2, onCounter2Change, true);
+}
+
+void loop() {
+  if (!Serial.available()) return;
+
+  char c = Serial.read();
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    Serial.println(">");
+  } else {
+    Serial.printf("> %c\r\n", c);
+  }
+
+  switch (c) {
+    // Restart ESP32
+    case '.': ESP.restart(); break;
+
+    // Print all settings
+    case 'p':
+    {
+      Serial.println("Current values:");
+      Serial.printf("%-12s%-12s\n", "Key", "Value");
+
+      for (size_t i = 0; i < counters.getSize(); i++) {
+        Serial.printf("%-12s", counters.getKey(static_cast<Counters>(i)));
+
+        uint32_t val;
+        if (!counters.getValue(static_cast<Counters>(i), val)) {
+          Serial.printf("%-12s\n", "Error!");
+          continue;
+        }
+
+        Serial.printf("%-12" PRIu32 "\n", val);
+      }
+
+      Serial.println();
+    } break;
+
+    // Set new values for each setting
+    case 's':
+    {
+      // Fires: global (x3), Counter_1 per-setting (x1), Counter_2 per-setting (x1)
+      Serial.println("Setting new values (global + Counter_1 + Counter_2 callbacks expected):");
+
+      for (size_t i = 0; i < counters.getSize(); i++) {
+        counters.setValue(static_cast<Counters>(i), random(1, 1000));
+      }
+
+      Serial.println();
+    } break;
+
+    // Format all settings to default values
+    case 'f':
+    {
+      // Fires: Counter_2 per-setting only (callable_on_format=true)
+      // Global and Counter_1 are silent (callable_on_format=false)
+      Serial.println("Formatting settings (only Counter_2 callback expected):");
+
+      uint8_t errors = counters.formatAll();
+
+      if (errors == 0) {
+        Serial.println("done.\n");
+      } else {
+        Serial.printf("failed with %u errors!\n\n", errors);
+      }
+    } break;
+  }
+}

--- a/examples/DefaultValueFallback/DefaultValueFallback.ino
+++ b/examples/DefaultValueFallback/DefaultValueFallback.ino
@@ -10,8 +10,10 @@
  * - The loop function reads the serial input and performs the following actions:
  *   - '.' restarts the ESP32.
  *   - 'p' prints all settings using getValueOrDefault() (typed API) and getValuePtrOrDefault()
- *         (ISettings pointer API). Since no key exists yet, both return the default value as
- *         fallback. After writing values with 's', they return the actual NVS values instead.
+ *         (ISettings pointer API). getValuePtrOrDefault() returns true on success (NVS or default)
+ *         and writes the value into the caller's buffer. Since no key exists yet, both functions
+ *         return the default value as fallback. After writing values with 's', they return the
+ *         actual NVS values instead.
  *   - 's' sets new values for the first two settings of each type (the third is intentionally
  *         left unwritten to keep the fallback case observable).
  */
@@ -137,12 +139,12 @@ void loop() {
       Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
       for (size_t i = 0; i < ptr->getSize(); i++) {
         uint32_t out;
-        const void* result = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
-        if (result) {
+        bool ok = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
+        if (ok) {
           Serial.printf("%-10s %-12" PRIu32 " %-12" PRIu32 "\n",
                         ptr->getKey(i),
                         ptr->getDefaultValueAs<uint32_t>(i),
-                        *static_cast<const uint32_t*>(result));
+                        out);
         }
       }
 
@@ -168,12 +170,12 @@ void loop() {
       Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
       for (size_t i = 0; i < ptr->getSize(); i++) {
         NVS::Str out{str_buf, sizeof(str_buf)};
-        const void* result = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
-        if (result) {
+        bool ok = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
+        if (ok) {
           Serial.printf("%-10s %-12s %-12s\n",
                         ptr->getKey(i),
                         ptr->getDefaultValueAs<NVS::StrView>(i).data,
-                        static_cast<const NVS::Str*>(result)->data);
+                        out.data);
         }
       }
 
@@ -208,14 +210,14 @@ void loop() {
       Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
       for (size_t i = 0; i < ptr->getSize(); i++) {
         NVS::ByteStream out{bs_buf, sizeof(bs_buf)};
-        const void* result = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
-        if (result) {
+        bool ok = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
+        if (ok) {
           NVS::ByteStreamView def = ptr->getDefaultValueAs<NVS::ByteStreamView>(i);
           NVS::fromHexToStr(def, hex_buf, sizeof(hex_buf));
           char def_str[NVS::hexStrSize(16)];
           memcpy(def_str, hex_buf, sizeof(def_str));
 
-          NVS::fromHexToStr(*static_cast<const NVS::ByteStream*>(result), hex_buf, sizeof(hex_buf));
+          NVS::fromHexToStr(out, hex_buf, sizeof(hex_buf));
           Serial.printf("%-10s %-12s %-12s\n", ptr->getKey(i), def_str, hex_buf);
         }
       }

--- a/examples/DefaultValueFallback/DefaultValueFallback.ino
+++ b/examples/DefaultValueFallback/DefaultValueFallback.ino
@@ -1,0 +1,246 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** Explanation of the example:
+ * - Three settings are created for each of: uint32_t, NVS::Str, and NVS::ByteStream.
+ * - In setup(), the NVS partition is fully erased and re-initialized, so no keys exist.
+ * - The loop function reads the serial input and performs the following actions:
+ *   - '.' restarts the ESP32.
+ *   - 'p' prints all settings using getValueOrDefault() (typed API) and getValuePtrOrDefault()
+ *         (ISettings pointer API). Since no key exists yet, both return the default value as
+ *         fallback. After writing values with 's', they return the actual NVS values instead.
+ *   - 's' sets new values for the first two settings of each type (the third is intentionally
+ *         left unwritten to keep the fallback case observable).
+ */
+
+#include <Arduino.h>
+
+#include "SettingsManagerESP32.h"
+
+// Three uint32_t settings, none formattable
+#define MY_UINTS(X)                \
+  X(Val_1, "Value 1", 100u, false) \
+  X(Val_2, "Value 2", 200u, false) \
+  X(Val_3, "Value 3", 300u, false)
+
+SETTINGS_CREATE_UINT32S(MyUInts, "ordefault", MY_UINTS)
+
+// Three string settings, none formattable
+#define MY_STRS(X)                         \
+  X(Str_1, "String 1", "default_1", false) \
+  X(Str_2, "String 2", "default_2", false) \
+  X(Str_3, "String 3", "default_3", false)
+
+SETTINGS_CREATE_STRINGS(MyStrs, "ordefault", MY_STRS)
+
+// Default byte blobs (stored in flash)
+const uint8_t bs1_data[] = {0xAA, 0xBB, 0xCC};
+const uint8_t bs2_data[] = {0x11, 0x22, 0x33};
+const uint8_t bs3_data[] = {0xDE, 0xAD, 0xBE};
+
+const NVS::ByteStreamView bs1_def{bs1_data, sizeof(bs1_data)};
+const NVS::ByteStreamView bs2_def{bs2_data, sizeof(bs2_data)};
+const NVS::ByteStreamView bs3_def{bs3_data, sizeof(bs3_data)};
+
+// Three ByteStream settings, none formattable
+#define MY_BYTESTREAMS(X)                 \
+  X(BS_1, "ByteStream 1", bs1_def, false) \
+  X(BS_2, "ByteStream 2", bs2_def, false) \
+  X(BS_3, "ByteStream 3", bs3_def, false)
+
+SETTINGS_CREATE_BYTE_STREAMS(MyByteStreams, "ordefault", MY_BYTESTREAMS)
+
+void setup() {
+  Serial.begin(115200);
+  delay(2000);
+
+  Serial.println("Starting...");
+
+  if (!NVS::init()) {
+    Serial.println("Failed to initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!st_MyUInts.begin() || !st_MyStrs.begin() || !st_MyByteStreams.begin()) {
+    Serial.println("Failed to open settings handles!");
+    while (true)
+      delay(1000);
+  }
+
+  // Handles must be closed before erasing the partition
+  st_MyUInts.end();
+  st_MyStrs.end();
+  st_MyByteStreams.end();
+
+  Serial.println("Erasing NVS partition...");
+  if (!NVS::erase()) {
+    Serial.println("Failed to erase NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  Serial.println("Re-initializing NVS...");
+  if (!NVS::init()) {
+    Serial.println("Failed to re-initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!st_MyUInts.begin() || !st_MyStrs.begin() || !st_MyByteStreams.begin()) {
+    Serial.println("Failed to re-open settings handles!");
+    while (true)
+      delay(1000);
+  }
+
+  Serial.println("NVS is now empty. No keys exist.");
+  Serial.println("Press 'p' to print values, 's' to set values.\n");
+}
+
+void loop() {
+  if (!Serial.available()) return;
+
+  char c = Serial.read();
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    Serial.println(">");
+  } else {
+    Serial.printf("> %c\r\n", c);
+  }
+
+  switch (c) {
+    // Restart ESP32
+    case '.': ESP.restart(); break;
+
+    case 'p':
+    {
+      // ---- uint32_t ----
+      Serial.println("=== uint32_t ===");
+
+      Serial.println("Typed API: getValueOrDefault()");
+      Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
+      for (size_t i = 0; i < st_MyUInts.getSize(); i++) {
+        uint32_t out;
+        uint32_t result = st_MyUInts.getValueOrDefault(static_cast<MyUInts>(i), out);
+        Serial.printf("%-10s %-12" PRIu32 " %-12" PRIu32 "\n",
+                      st_MyUInts.getKey(static_cast<MyUInts>(i)),
+                      st_MyUInts.getDefaultValue(static_cast<MyUInts>(i)),
+                      result);
+      }
+
+      Serial.println("ISettings API: getValuePtrOrDefault()");
+      NVS::ISettings* ptr = &st_MyUInts;
+      Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
+      for (size_t i = 0; i < ptr->getSize(); i++) {
+        uint32_t out;
+        const void* result = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
+        if (result) {
+          Serial.printf("%-10s %-12" PRIu32 " %-12" PRIu32 "\n",
+                        ptr->getKey(i),
+                        ptr->getDefaultValueAs<uint32_t>(i),
+                        *static_cast<const uint32_t*>(result));
+        }
+      }
+
+      Serial.println();
+
+      // ---- NVS::Str ----
+      Serial.println("=== NVS::Str ===");
+      static char str_buf[32];
+
+      Serial.println("Typed API: getValueOrDefault()");
+      Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
+      for (size_t i = 0; i < st_MyStrs.getSize(); i++) {
+        NVS::Str out{str_buf, sizeof(str_buf)};
+        NVS::Str result = st_MyStrs.getValueOrDefault(static_cast<MyStrs>(i), out);
+        Serial.printf("%-10s %-12s %-12s\n",
+                      st_MyStrs.getKey(static_cast<MyStrs>(i)),
+                      st_MyStrs.getDefaultValue(static_cast<MyStrs>(i)).data,
+                      result.data);
+      }
+
+      Serial.println("ISettings API: getValuePtrOrDefault()");
+      ptr = &st_MyStrs;
+      Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
+      for (size_t i = 0; i < ptr->getSize(); i++) {
+        NVS::Str out{str_buf, sizeof(str_buf)};
+        const void* result = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
+        if (result) {
+          Serial.printf("%-10s %-12s %-12s\n",
+                        ptr->getKey(i),
+                        ptr->getDefaultValueAs<NVS::StrView>(i).data,
+                        static_cast<const NVS::Str*>(result)->data);
+        }
+      }
+
+      Serial.println();
+
+      // ---- NVS::ByteStream ----
+      Serial.println("=== NVS::ByteStream ===");
+      static uint8_t bs_buf[16];
+      static char hex_buf[NVS::hexStrSize(16)];
+
+      Serial.println("Typed API: getValueOrDefault()");
+      Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
+      for (size_t i = 0; i < st_MyByteStreams.getSize(); i++) {
+        NVS::ByteStream out{bs_buf, sizeof(bs_buf)};
+        NVS::ByteStream result =
+          st_MyByteStreams.getValueOrDefault(static_cast<MyByteStreams>(i), out);
+
+        NVS::ByteStreamView def = st_MyByteStreams.getDefaultValue(static_cast<MyByteStreams>(i));
+        NVS::fromHexToStr(def, hex_buf, sizeof(hex_buf));
+        char def_str[NVS::hexStrSize(16)];
+        memcpy(def_str, hex_buf, sizeof(def_str));
+
+        NVS::fromHexToStr(result, hex_buf, sizeof(hex_buf));
+        Serial.printf("%-10s %-12s %-12s\n",
+                      st_MyByteStreams.getKey(static_cast<MyByteStreams>(i)),
+                      def_str,
+                      hex_buf);
+      }
+
+      Serial.println("ISettings API: getValuePtrOrDefault()");
+      ptr = &st_MyByteStreams;
+      Serial.printf("%-10s %-12s %-12s\n", "Key", "Default", "Result");
+      for (size_t i = 0; i < ptr->getSize(); i++) {
+        NVS::ByteStream out{bs_buf, sizeof(bs_buf)};
+        const void* result = ptr->getValuePtrOrDefault(i, &out, sizeof(out));
+        if (result) {
+          NVS::ByteStreamView def = ptr->getDefaultValueAs<NVS::ByteStreamView>(i);
+          NVS::fromHexToStr(def, hex_buf, sizeof(hex_buf));
+          char def_str[NVS::hexStrSize(16)];
+          memcpy(def_str, hex_buf, sizeof(def_str));
+
+          NVS::fromHexToStr(*static_cast<const NVS::ByteStream*>(result), hex_buf, sizeof(hex_buf));
+          Serial.printf("%-10s %-12s %-12s\n", ptr->getKey(i), def_str, hex_buf);
+        }
+      }
+
+      Serial.println();
+    } break;
+
+    case 's':
+    {
+      // The third setting of each type is intentionally left unwritten
+      Serial.println("Setting uint32 Val_1=999, Val_2=888...");
+      st_MyUInts.setValue(MyUInts::Val_1, 999u);
+      st_MyUInts.setValue(MyUInts::Val_2, 888u);
+
+      Serial.println("Setting string Str_1=\"hello_1\", Str_2=\"hello_2\"...");
+      st_MyStrs.setValue(MyStrs::Str_1, NVS::StrView{"hello_1"});
+      st_MyStrs.setValue(MyStrs::Str_2, NVS::StrView{"hello_2"});
+
+      const uint8_t new_bs1[] = {0x01, 0x02, 0x03};
+      const uint8_t new_bs2[] = {0x04, 0x05, 0x06};
+      Serial.println("Setting ByteStream BS_1=010203, BS_2=040506...");
+      st_MyByteStreams.setValue(MyByteStreams::BS_1, NVS::ByteStreamView{new_bs1, sizeof(new_bs1)});
+      st_MyByteStreams.setValue(MyByteStreams::BS_2, NVS::ByteStreamView{new_bs2, sizeof(new_bs2)});
+
+      Serial.println("Done. Press 'p' to see the updated values.\n");
+    } break;
+  }
+}

--- a/examples/Floats/Floats.ino
+++ b/examples/Floats/Floats.ino
@@ -5,11 +5,11 @@
  */
 
 /** Explanation of the example:
- * - Three settings are created, all with formattable values.
+ * - Three float settings are created, all with formattable values.
  * - The loop function reads the serial input and performs the following actions:
  *  - '.' restarts the ESP32.
  *  - 'p' prints all settings, including key, hint, default value, and current value.
- *  - 's' sets new values for each setting.
+ *  - 's' sets each setting to a random float value.
  *  - '1' sets a new value only for the first setting.
  *  - 'f' formats all settings to their default values.
  */
@@ -18,18 +18,18 @@
 
 #include "SettingsManagerESP32.h"
 
-// Integers, all formattable
-#define UINTS(X)               \
-  X(UInt_1, "UInt 1", 1, true) \
-  X(UInt_2, "UInt 2", 2, true) \
-  X(UInt_3, "UInt 3", 3, true)
+// Floats, all formattable
+#define FLOATS(X)                   \
+  X(Float_1, "Float 1", 1.0f, true) \
+  X(Float_2, "Float 2", 2.0f, true) \
+  X(Float_3, "Float 3", 3.0f, true)
 
-// Enum for integer settings
-enum class UInts : uint8_t { UINTS(SETTINGS_EXPAND_ENUM_CLASS) };
+// Enum for float settings
+enum class Floats : uint8_t { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
 
-// Settings object for integers, namespace "esp32"
-NVS::Settings<uint32_t, UInts, SETTINGS_COUNT(UINTS)> uints("esp32",
-                                                            {UINTS(SETTINGS_EXPAND_SETTINGS)});
+// Settings object for floats, namespace "esp32"
+NVS::Settings<float, Floats, SETTINGS_COUNT(FLOATS)> floats("esp32",
+                                                            {FLOATS(SETTINGS_EXPAND_SETTINGS)});
 
 void setup() {
   Serial.begin(115200);
@@ -43,7 +43,7 @@ void setup() {
       delay(1000);
   }
 
-  if (!uints.begin()) {
+  if (!floats.begin()) {
     Serial.println("Failed to open settings handle!");
     while (true)
       delay(1000);
@@ -72,18 +72,18 @@ void loop() {
       Serial.println("List of settings:");
       Serial.printf("%-10s%-10s%-10s%-10s\n", "Key", "Hint", "Default", "Value");
 
-      for (size_t i = 0; i < uints.getSize(); i++) {
-        Serial.printf("%-10s", uints.getKey(static_cast<UInts>(i)));
-        Serial.printf("%-10s", uints.getHint(static_cast<UInts>(i)));
-        Serial.printf("%-10" PRIu32, uints.getDefaultValue(static_cast<UInts>(i)));
+      for (size_t i = 0; i < floats.getSize(); i++) {
+        Serial.printf("%-10s", floats.getKey(static_cast<Floats>(i)));
+        Serial.printf("%-10s", floats.getHint(static_cast<Floats>(i)));
+        Serial.printf("%-10.2f", floats.getDefaultValue(static_cast<Floats>(i)));
 
-        uint32_t val;
-        if (!uints.getValue(static_cast<UInts>(i), val)) {
+        float val;
+        if (!floats.getValue(static_cast<Floats>(i), val)) {
           Serial.printf("%-10s\n", "Error!");
           continue;
         }
 
-        Serial.printf("%-10" PRIu32 "\n", val);
+        Serial.printf("%-10.2f\n", val);
       }
 
       Serial.println();
@@ -94,12 +94,12 @@ void loop() {
     {
       Serial.println("Setting new values...");
 
-      for (size_t i = 0; i < uints.getSize(); i++) {
-        const char* key    = uints.getKey(static_cast<UInts>(i));
-        uint32_t new_value = random(0, 100);
+      for (size_t i = 0; i < floats.getSize(); i++) {
+        const char* key = floats.getKey(static_cast<Floats>(i));
+        float new_value = random(0, 10000) / 100.0f; // 0.00 to 99.99
 
-        if (uints.setValue(static_cast<UInts>(i), new_value)) {
-          Serial.printf("- Set %s to %" PRIu32 "\n", key, new_value);
+        if (floats.setValue(static_cast<Floats>(i), new_value)) {
+          Serial.printf("- Set %s to %.2f\n", key, new_value);
         } else {
           Serial.printf("- Failed to set value for %s\n", key);
         }
@@ -113,11 +113,11 @@ void loop() {
     {
       Serial.println("Modifying first setting...");
 
-      const char* key    = uints.getKey(UInts::UInt_1);
-      uint32_t new_value = random(0, 100);
+      const char* key = floats.getKey(Floats::Float_1);
+      float new_value = random(0, 10000) / 100.0f;
 
-      if (uints.setValue(UInts::UInt_1, new_value)) {
-        Serial.printf("- Set %s to %" PRIu32 "\n", key, new_value);
+      if (floats.setValue(Floats::Float_1, new_value)) {
+        Serial.printf("- Set %s to %.2f\n", key, new_value);
       } else {
         Serial.printf("- Failed to set value for %s\n", key);
       }
@@ -130,7 +130,7 @@ void loop() {
     {
       Serial.print("Formatting settings... ");
 
-      uint8_t errors = uints.formatAll();
+      uint8_t errors = floats.formatAll();
 
       if (errors == 0) {
         Serial.println("done.\n");

--- a/examples/MultipleInstances/MultipleInstances.ino
+++ b/examples/MultipleInstances/MultipleInstances.ino
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** Explanation of the example:
+ * - Two separate Settings instances are created with the same settings list but different
+ * namespaces.
+ * - The loop function reads the serial input and performs the following actions:
+ * - '.' restarts the ESP32.
+ * - 'p' prints all settings for both instances, demonstrating that they operate independently.
+ * - 's' sets new random values for each setting in both instances.
+ * - '1' sets a new random value only for the first setting in both instances.
+ * - 'f' formats all settings in both instances to their default values.
+ */
+
+#include <Arduino.h>
+
+#include "SettingsManagerESP32.h"
+
+// Integers, all formattable
+#define UINTS(X)               \
+  X(UInt_1, "UInt 1", 1, true) \
+  X(UInt_2, "UInt 2", 2, true) \
+  X(UInt_3, "UInt 3", 3, true)
+
+// Enum for integer settings
+enum class UInts : uint8_t { UINTS(SETTINGS_EXPAND_ENUM_CLASS) };
+
+// Two instances using the same settings list but different namespaces, demonstrating that they
+// operate independently
+// clang-format off
+NVS::Settings<uint32_t, UInts, SETTINGS_COUNT(UINTS)>
+  uints1("uints1",{UINTS(SETTINGS_EXPAND_SETTINGS)});
+
+NVS::Settings<uint32_t, UInts, SETTINGS_COUNT(UINTS)>
+  uints2("uints2",{UINTS(SETTINGS_EXPAND_SETTINGS)});
+// clang-format on
+
+void setup() {
+  Serial.begin(115200);
+  delay(2000);
+
+  Serial.println("Starting...");
+
+  if (!NVS::init()) {
+    Serial.println("Failed to initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!uints1.begin()) {
+    Serial.println("Failed to open uints1 settings handle!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!uints2.begin()) {
+    Serial.println("Failed to open uints2 settings handle!");
+    while (true)
+      delay(1000);
+  }
+}
+
+void loop() {
+  if (!Serial.available()) return;
+
+  char c = Serial.read();
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    Serial.println(">");
+  } else {
+    Serial.printf("> %c\r\n", c);
+  }
+
+  switch (c) {
+    // Restart ESP32
+    case '.': ESP.restart(); break;
+
+    // Print all settings
+    case 'p':
+    {
+      Serial.println("List of settings:");
+      Serial.printf("%-10s%-10s%-10s%-10s%-10s\n", "Namespace", "Key", "Hint", "Default", "Value");
+
+      for (size_t i = 0; i < uints1.getSize(); i++) {
+        Serial.printf("%-10s", uints1.getNamespace());
+        Serial.printf("%-10s", uints1.getKey(static_cast<UInts>(i)));
+        Serial.printf("%-10s", uints1.getHint(static_cast<UInts>(i)));
+        Serial.printf("%-10" PRIu32, uints1.getDefaultValue(static_cast<UInts>(i)));
+
+        uint32_t val;
+        if (!uints1.getValue(static_cast<UInts>(i), val)) {
+          Serial.printf("%-10s\n", "Error!");
+          continue;
+        }
+
+        Serial.printf("%-10" PRIu32 "\n", val);
+      }
+
+      for (size_t i = 0; i < uints2.getSize(); i++) {
+        Serial.printf("%-10s", uints2.getNamespace());
+        Serial.printf("%-10s", uints2.getKey(static_cast<UInts>(i)));
+        Serial.printf("%-10s", uints2.getHint(static_cast<UInts>(i)));
+        Serial.printf("%-10" PRIu32, uints2.getDefaultValue(static_cast<UInts>(i)));
+
+        uint32_t val;
+        if (!uints2.getValue(static_cast<UInts>(i), val)) {
+          Serial.printf("%-10s\n", "Error!");
+          continue;
+        }
+
+        Serial.printf("%-10" PRIu32 "\n", val);
+      }
+
+      Serial.println();
+    } break;
+
+    // Set new values for each setting
+    case 's':
+    {
+      Serial.println("Setting new values...");
+
+      for (size_t i = 0; i < uints1.getSize(); i++) {
+        const char* key    = uints1.getKey(static_cast<UInts>(i));
+        uint32_t new_value = random(0, 100);
+
+        if (uints1.setValue(static_cast<UInts>(i), new_value)) {
+          Serial.printf("- Set %s/%s to %" PRIu32 "\n", uints1.getNamespace(), key, new_value);
+        } else {
+          Serial.printf("- Failed to set value for %s/%s\n", uints1.getNamespace(), key);
+        }
+      }
+
+      for (size_t i = 0; i < uints2.getSize(); i++) {
+        const char* key    = uints2.getKey(static_cast<UInts>(i));
+        uint32_t new_value = random(0, 100);
+
+        if (uints2.setValue(static_cast<UInts>(i), new_value)) {
+          Serial.printf("- Set %s/%s to %" PRIu32 "\n", uints2.getNamespace(), key, new_value);
+        } else {
+          Serial.printf("- Failed to set value for %s/%s\n", uints2.getNamespace(), key);
+        }
+      }
+
+      Serial.println();
+    } break;
+
+    // Modify only the first setting, leaving the others unchanged
+    case '1':
+    {
+      Serial.println("Modifying first setting...");
+
+      // Instance 1
+      const char* key    = uints1.getKey(UInts::UInt_1);
+      uint32_t new_value = random(0, 100);
+
+      if (uints1.setValue(UInts::UInt_1, new_value)) {
+        Serial.printf("- Set %s/%s to %" PRIu32 "\n", uints1.getNamespace(), key, new_value);
+      } else {
+        Serial.printf("- Failed to set value for %s/%s\n", uints1.getNamespace(), key);
+      }
+
+      // Instance 2
+      key       = uints2.getKey(UInts::UInt_1);
+      new_value = random(0, 100);
+
+      if (uints2.setValue(UInts::UInt_1, new_value)) {
+        Serial.printf("- Set %s/%s to %" PRIu32 "\n", uints2.getNamespace(), key, new_value);
+      } else {
+        Serial.printf("- Failed to set value for %s/%s\n", uints2.getNamespace(), key);
+      }
+
+      Serial.println();
+    } break;
+
+    // Format all settings to default values
+    case 'f':
+    {
+      Serial.print("Formatting settings... ");
+
+      uint8_t errors = uints1.formatAll();
+      errors += uints2.formatAll();
+
+      if (errors == 0) {
+        Serial.println("done.\n");
+      } else {
+        Serial.printf("failed with %u errors!\n\n", errors);
+      }
+    } break;
+  }
+}

--- a/examples/SettingsInCustomClass/SettingsInCustomClass.ino
+++ b/examples/SettingsInCustomClass/SettingsInCustomClass.ino
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** Explanation of the example:
+ * - This example demonstrates how to use Settings objects within a custom class. This is useful for
+ *   encapsulating related settings and logic together.
+ * - A class `MyDevice` is defined, which contains a Settings object for uint32_t values. The
+ *   constructor takes a namespace name, allowing multiple instances of `MyDevice` to coexist with
+ *   their own separate settings.
+ * - The loop function reads the serial input and performs the following actions:
+ * - '.' restarts the ESP32.
+ * - 'p' prints all settings for both instances, demonstrating that they operate independently.
+ * - 's' sets new random values for each setting in both instances.
+ * - '1' sets a new random value only for the first setting in both instances.
+ * - 'f' formats all settings in both instances to their default values.
+ */
+
+#include <Arduino.h>
+
+#include "SettingsManagerESP32.h"
+
+// Integers, all formattable
+#define UINTS(X)               \
+  X(UInt_1, "UInt 1", 1, true) \
+  X(UInt_2, "UInt 2", 2, true) \
+  X(UInt_3, "UInt 3", 3, true)
+
+// Enum for integer settings
+enum class UInts : uint8_t { UINTS(SETTINGS_EXPAND_ENUM_CLASS) };
+
+// Example class demonstrating usage of Settings within a custom class.
+// Each instance instantiates its own Settings object with a different namespace, demonstrating that
+// multiple instances can coexist without interference.
+class MyDevice {
+  public:
+  using Prefs = NVS::Settings<uint32_t, UInts, SETTINGS_COUNT(UINTS)>;
+
+  MyDevice(const char* ns_name)
+      : _uints(ns_name, {UINTS(SETTINGS_EXPAND_SETTINGS)}) {}
+
+  Prefs& getSettings() { return _uints; }
+
+  private:
+  Prefs _uints;
+};
+
+// Create two devices with different namespaces
+MyDevice device1("device1");
+MyDevice device2("device2");
+
+void setup() {
+  Serial.begin(115200);
+  delay(2000);
+
+  Serial.println("Starting...");
+
+  if (!NVS::init()) {
+    Serial.println("Failed to initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!device1.getSettings().begin()) {
+    Serial.println("Failed to open device1 settings handle!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!device2.getSettings().begin()) {
+    Serial.println("Failed to open device2 settings handle!");
+    while (true)
+      delay(1000);
+  }
+}
+
+void loop() {
+  if (!Serial.available()) return;
+
+  char c = Serial.read();
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    Serial.println(">");
+  } else {
+    Serial.printf("> %c\r\n", c);
+  }
+
+  switch (c) {
+    // Restart ESP32
+    case '.': ESP.restart(); break;
+
+    // Print all settings
+    case 'p':
+    {
+      Serial.println("List of settings:");
+      Serial.printf("%-10s%-10s%-10s%-10s%-10s\n", "Namespace", "Key", "Hint", "Default", "Value");
+
+      for (size_t i = 0; i < device1.getSettings().getSize(); i++) {
+        Serial.printf("%-10s", device1.getSettings().getNamespace());
+        Serial.printf("%-10s", device1.getSettings().getKey(static_cast<UInts>(i)));
+        Serial.printf("%-10s", device1.getSettings().getHint(static_cast<UInts>(i)));
+        Serial.printf("%-10" PRIu32, device1.getSettings().getDefaultValue(static_cast<UInts>(i)));
+
+        uint32_t val;
+        if (!device1.getSettings().getValue(static_cast<UInts>(i), val)) {
+          Serial.printf("%-10s\n", "Error!");
+          continue;
+        }
+
+        Serial.printf("%-10" PRIu32 "\n", val);
+      }
+
+      for (size_t i = 0; i < device2.getSettings().getSize(); i++) {
+        Serial.printf("%-10s", device2.getSettings().getNamespace());
+        Serial.printf("%-10s", device2.getSettings().getKey(static_cast<UInts>(i)));
+        Serial.printf("%-10s", device2.getSettings().getHint(static_cast<UInts>(i)));
+        Serial.printf("%-10" PRIu32, device2.getSettings().getDefaultValue(static_cast<UInts>(i)));
+
+        uint32_t val;
+        if (!device2.getSettings().getValue(static_cast<UInts>(i), val)) {
+          Serial.printf("%-10s\n", "Error!");
+          continue;
+        }
+
+        Serial.printf("%-10" PRIu32 "\n", val);
+      }
+
+      Serial.println();
+    } break;
+
+    // Set new values for each setting
+    case 's':
+    {
+      Serial.println("Setting new values...");
+
+      for (size_t i = 0; i < device1.getSettings().getSize(); i++) {
+        const char* key    = device1.getSettings().getKey(static_cast<UInts>(i));
+        uint32_t new_value = random(0, 100);
+
+        if (device1.getSettings().setValue(static_cast<UInts>(i), new_value)) {
+          Serial.printf(
+            "- Set %s/%s to %" PRIu32 "\n", device1.getSettings().getNamespace(), key, new_value);
+        } else {
+          Serial.printf(
+            "- Failed to set value for %s/%s\n", device1.getSettings().getNamespace(), key);
+        }
+      }
+
+      for (size_t i = 0; i < device2.getSettings().getSize(); i++) {
+        const char* key    = device2.getSettings().getKey(static_cast<UInts>(i));
+        uint32_t new_value = random(0, 100);
+
+        if (device2.getSettings().setValue(static_cast<UInts>(i), new_value)) {
+          Serial.printf(
+            "- Set %s/%s to %" PRIu32 "\n", device2.getSettings().getNamespace(), key, new_value);
+        } else {
+          Serial.printf(
+            "- Failed to set value for %s/%s\n", device2.getSettings().getNamespace(), key);
+        }
+      }
+
+      Serial.println();
+    } break;
+
+    // Modify only the first setting, leaving the others unchanged
+    case '1':
+    {
+      Serial.println("Modifying first setting...");
+
+      // Instance 1
+      const char* key    = device1.getSettings().getKey(UInts::UInt_1);
+      uint32_t new_value = random(0, 100);
+
+      if (device1.getSettings().setValue(UInts::UInt_1, new_value)) {
+        Serial.printf(
+          "- Set %s/%s to %" PRIu32 "\n", device1.getSettings().getNamespace(), key, new_value);
+      } else {
+        Serial.printf(
+          "- Failed to set value for %s/%s\n", device1.getSettings().getNamespace(), key);
+      }
+
+      // Instance 2
+      key       = device2.getSettings().getKey(UInts::UInt_1);
+      new_value = random(0, 100);
+
+      if (device2.getSettings().setValue(UInts::UInt_1, new_value)) {
+        Serial.printf(
+          "- Set %s/%s to %" PRIu32 "\n", device2.getSettings().getNamespace(), key, new_value);
+      } else {
+        Serial.printf(
+          "- Failed to set value for %s/%s\n", device2.getSettings().getNamespace(), key);
+      }
+
+      Serial.println();
+    } break;
+
+    // Format all settings to default values
+    case 'f':
+    {
+      Serial.print("Formatting settings... ");
+
+      uint8_t errors = device1.getSettings().formatAll();
+      errors += device2.getSettings().formatAll();
+
+      if (errors == 0) {
+        Serial.println("done.\n");
+      } else {
+        Serial.printf("failed with %u errors!\n\n", errors);
+      }
+    } break;
+  }
+}

--- a/examples/Strings/Strings.ino
+++ b/examples/Strings/Strings.ino
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -10,8 +10,11 @@
  *  - '.' restarts the ESP32.
  *  - 'p' prints all settings, including key, hint, default value, and current value.
  *  - 's' sets new values for each setting.
+ *  - '1' sets a new value only for the first setting.
  *  - 'f' formats all settings to their default values.
  */
+
+#include <Arduino.h>
 
 #include "SettingsManagerESP32.h"
 
@@ -21,16 +24,31 @@
   X(Str_2, "Str 2", "str 2", true) \
   X(Str_3, "Str 3", "str 3", true)
 
+// Enum for string settings
 enum class Strings : uint8_t { STRINGS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<const char*, Strings, SETTINGS_COUNT(STRINGS)> strings = {
-  STRINGS(SETTINGS_EXPAND_SETTINGS)};
+
+// Settings object for strings, namespace "esp32"
+NVS::Settings<NVS::Str, Strings, SETTINGS_COUNT(STRINGS)>
+  strings("esp32", {STRINGS(SETTINGS_EXPAND_SETTINGS)});
 
 void setup() {
   Serial.begin(115200);
+  delay(2000);
+
   Serial.println("Starting...");
 
-  // Initialize NVS namespace
-  nvs.begin("esp32");
+  // Initialize NVS flash partition, then open the namespace handle
+  if (!NVS::init()) {
+    Serial.println("Failed to initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!strings.begin()) {
+    Serial.println("Failed to open settings handle!");
+    while (true)
+      delay(1000);
+  }
 }
 
 void loop() {
@@ -40,6 +58,13 @@ void loop() {
   }
 
   char c = Serial.read();
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    Serial.println(">");
+  } else {
+    Serial.printf("> %c\r\n", c);
+  }
 
   switch (c) {
     // Restart ESP32
@@ -49,17 +74,22 @@ void loop() {
     case 'p':
     {
       Serial.println("List of settings:");
+      Serial.printf("%-10s%-10s%-10s%-10s\n", "Key", "Hint", "DefVal", "Value");
 
-      Serial.printf("Key\t\tHint\t\tDefVal\t\tValue\n");
+      static char buf[32];
+      static NVS::Str value{buf, sizeof(buf)};
 
       for (size_t i = 0; i < strings.getSize(); i++) {
-        Serial.printf("%s\t\t", strings.getKey(static_cast<Strings>(i)));
-        Serial.printf("%s\t\t", strings.getHint(static_cast<Strings>(i)));
-        Serial.printf("%s\t\t", strings.getDefaultValue(static_cast<Strings>(i)));
-        Serial.printf("%s\n", strings.getValue(static_cast<Strings>(i)));
+        Serial.printf("%-10s", strings.getKey(static_cast<Strings>(i)));
+        Serial.printf("%-10s", strings.getHint(static_cast<Strings>(i)));
+        Serial.printf("%-10s", strings.getDefaultValue(static_cast<Strings>(i)).data);
 
-        // IMPORTANT: release the mutex when done using a value
-        strings.giveMutex();
+        if (!strings.getValue(static_cast<Strings>(i), value)) {
+          Serial.printf("%-10s\n", "Error!");
+          continue;
+        }
+
+        Serial.printf("%-10s\n", value.data);
       }
 
       Serial.println();
@@ -68,14 +98,13 @@ void loop() {
     // Set new values for each setting
     case 's':
     {
+      static char buffer[32];
       Serial.println("Setting new values...");
 
       for (size_t i = 0; i < strings.getSize(); i++) {
         const char* key = strings.getKey(static_cast<Strings>(i));
 
-        static char buffer[SETTINGS_STRING_BUFFER_SIZE];
         uint32_t new_value = random(0, 100);
-
         snprintf(buffer, sizeof(buffer), "str %" PRIu32, new_value);
 
         if (strings.setValue(static_cast<Strings>(i), buffer)) {
@@ -83,6 +112,26 @@ void loop() {
         } else {
           Serial.printf("- Failed to set value for %s\n", key);
         }
+      }
+
+      Serial.println();
+    } break;
+
+    // Modify only the first setting, leaving the others unchanged
+    case '1':
+    {
+      static char buffer[32];
+      Serial.println("Modifying first setting...");
+
+      const char* key = strings.getKey(Strings::Str_1);
+
+      uint32_t new_value = random(0, 100);
+      snprintf(buffer, sizeof(buffer), "str %" PRIu32, new_value);
+
+      if (strings.setValue(Strings::Str_1, buffer)) {
+        Serial.printf("- Set %s to %s\n", key, buffer);
+      } else {
+        Serial.printf("- Failed to set value for %s\n", key);
       }
 
       Serial.println();

--- a/examples/Utilities/Utilities.ino
+++ b/examples/Utilities/Utilities.ino
@@ -1,0 +1,175 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** Explanation of the example:
+ * - Two ByteStream settings are created, both with formattable values.
+ * - The loop function reads the serial input and performs the following actions:
+ *   - '.' restarts the ESP32.
+ *   - 'p' prints all settings using typeToStr() and formatToStr().
+ *   - 'e' encodes the current value of each setting to hex strings (both compact and spaced) using
+ *         toHexStr() and hexStrSize().
+ *   - 'd' decodes hard-coded hex strings (compact and spaced) using fromHexStr() and saves them.
+ */
+
+#include <Arduino.h>
+
+#include "SettingsManagerESP32.h"
+
+// Default values (read-only views — data lives in flash)
+const uint8_t bs1_data[]          = {0xDE, 0xAD, 0xBE, 0xEF};
+const NVS::ByteStreamView bs1_def = {bs1_data, sizeof(bs1_data), NVS::ByteStream::Format::Hex};
+
+const uint8_t bs2_data[]          = {0x01, 0x02, 0x03, 0x04};
+const NVS::ByteStreamView bs2_def = {bs2_data, sizeof(bs2_data), NVS::ByteStream::Format::Hex};
+
+// ByteStream settings, all formattable
+#define BYTESTREAMS(X)             \
+  X(BS_1, "blob 1", bs1_def, true) \
+  X(BS_2, "blob 2", bs2_def, true)
+
+SETTINGS_CREATE_BYTE_STREAMS(ByteStreams, "esp32", BYTESTREAMS)
+
+void setup() {
+  Serial.begin(115200);
+  delay(2000);
+
+  Serial.println("Starting...");
+
+  if (!NVS::init()) {
+    Serial.println("Failed to initialize NVS!");
+    while (true)
+      delay(1000);
+  }
+
+  if (!st_ByteStreams.begin()) {
+    Serial.println("Failed to open settings handle!");
+    while (true)
+      delay(1000);
+  }
+}
+
+void loop() {
+  if (!Serial.available()) return;
+
+  char c = Serial.read();
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    Serial.println(">");
+  } else {
+    Serial.printf("> %c\r\n", c);
+  }
+
+  switch (c) {
+    case '.': ESP.restart(); break;
+
+    case 'p':
+    {
+      Serial.printf("Settings type: %s\n\n", NVS::typeToStr(st_ByteStreams.getType()));
+
+      static uint8_t buf[32];
+
+      // Allocate exact buffer sizes using hexStrSize()
+      static char compact_buf[NVS::hexStrSize(32)];
+      static char spaced_buf[NVS::hexStrSize(32, true)];
+
+      for (size_t i = 0; i < st_ByteStreams.getSize(); i++) {
+        NVS::ByteStreamView def = st_ByteStreams.getDefaultValue(static_cast<ByteStreams>(i));
+
+        Serial.printf("Key    : %s\n", st_ByteStreams.getKey(static_cast<ByteStreams>(i)));
+        Serial.printf("Hint   : %s\n", st_ByteStreams.getHint(static_cast<ByteStreams>(i)));
+        Serial.printf("Format : %s\n", NVS::formatToStr(def.format));
+
+        if (NVS::fromHexToStr(def, compact_buf, sizeof(compact_buf))) {
+          Serial.printf("Default: %s\n", compact_buf);
+        }
+
+        NVS::ByteStream value{buf, sizeof(buf), def.format};
+        if (st_ByteStreams.getValue(static_cast<ByteStreams>(i), value)) {
+          NVS::fromHexToStr(value, compact_buf, sizeof(compact_buf));
+          NVS::fromHexToStr(value, spaced_buf, sizeof(spaced_buf), true);
+          Serial.printf("Value  : %s (%s)\n", compact_buf, spaced_buf);
+        } else {
+          Serial.printf("Value  : (not saved)\n");
+        }
+
+        Serial.println();
+      }
+    } break;
+
+    case 'e':
+    {
+      Serial.println("Encoding current values to hex strings:");
+
+      static uint8_t buf[32];
+
+      // Allocate exact buffer sizes using hexStrSize()
+      static char compact_buf[NVS::hexStrSize(32)];
+      static char spaced_buf[NVS::hexStrSize(32, true)];
+
+      for (size_t i = 0; i < st_ByteStreams.getSize(); i++) {
+        const char* key         = st_ByteStreams.getKey(static_cast<ByteStreams>(i));
+        NVS::ByteStreamView def = st_ByteStreams.getDefaultValue(static_cast<ByteStreams>(i));
+        NVS::ByteStream value{buf, sizeof(buf), def.format};
+
+        if (!st_ByteStreams.getValue(static_cast<ByteStreams>(i), value)) {
+          Serial.printf("- %s: (not saved)\n", key);
+          continue;
+        }
+
+        NVS::fromHexToStr(value, compact_buf, sizeof(compact_buf));
+        NVS::fromHexToStr(value, spaced_buf, sizeof(spaced_buf), true);
+        Serial.printf("- %s: %s (%s)\n", key, compact_buf, spaced_buf);
+      }
+
+      Serial.println();
+    } break;
+
+    case 'd':
+    {
+      Serial.println("Decoding hex strings and saving...");
+
+      // First setting: compact format ("CAFEBABE")
+      // Second setting: spaced format ("0A 0B 0C 0D")
+      static const char* hex_compact = "CAFEBABE";
+      static const char* hex_spaced  = "0A 0B 0C 0D";
+
+      static uint8_t buf[32];
+
+      // Decode compact hex string
+      {
+        const char* key = st_ByteStreams.getKey(static_cast<ByteStreams>(0));
+        NVS::ByteStream value{buf, sizeof(buf)};
+
+        if (!NVS::fromStrToHex(hex_compact, value)) {
+          Serial.printf("- %s: failed to decode \"%s\"\n", key, hex_compact);
+        } else if (st_ByteStreams.setValue(static_cast<ByteStreams>(0), value)) {
+          Serial.printf("- %s: saved \"%s\"\n", key, hex_compact);
+        } else {
+          Serial.printf("- %s: failed to save\n", key);
+        }
+      }
+
+      // Decode spaced hex string
+      {
+        const char* key = st_ByteStreams.getKey(static_cast<ByteStreams>(1));
+        NVS::ByteStream value{buf, sizeof(buf)};
+
+        if (!NVS::fromStrToHex(hex_spaced, value, true)) {
+          Serial.printf("- %s: failed to decode \"%s\"\n", key, hex_spaced);
+        } else if (st_ByteStreams.setValue(static_cast<ByteStreams>(1), value)) {
+          Serial.printf("- %s: saved \"%s\"\n", key, hex_spaced);
+        } else {
+          Serial.printf("- %s: failed to save\n", key);
+        }
+      }
+
+      Serial.println();
+    } break;
+
+    default: break;
+  }
+}

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "SettingsManagerESP32",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "authors": {
     "name": "Maximiliano Ramirez",
     "email": "maximiliano.ramirezbravo@gmail.com"

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=SettingsManagerESP32
-version=3.1.0
+version=4.0.0
 author=Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
 maintainer=Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
-sentence=Abstraction over ESP32 Arduino Preferences library to make your life easier.
+sentence=Abstraction over ESP32 NVS library to make your life easier.
 paragraph=Manage your ESP32 device preferences effortlessly with the SettingsManagerESP32 library. This powerful yet user-friendly library abstract away the complexities of dealing with ESP32 Non-Volatile Storage, providing you with a seamless and intuitive interface to store and retrieve your device settings.
 category=Data Storage
 url=https://github.com/alkonosst/SettingsManagerESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,12 +13,13 @@ lib_dir = .
 ; src_dir = examples/Booleans
 ; src_dir = examples/Bytestreams
 ; src_dir = examples/Callbacks
+src_dir = examples/DefaultValueFallback
 ; src_dir = examples/Floats
 ; src_dir = examples/Integers
 ; src_dir = examples/MultipleInstances
 ; src_dir = examples/SettingsInCustomClass
 ; src_dir = examples/Strings
-src_dir = examples/Utilities
+; src_dir = examples/Utilities
 
 [env:esp32-s3]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,18 +10,24 @@
 
 [platformio]
 lib_dir = .
+; src_dir = examples/Booleans
+; src_dir = examples/Bytestreams
+; src_dir = examples/Callbacks
+; src_dir = examples/Floats
 ; src_dir = examples/Integers
+; src_dir = examples/MultipleInstances
+; src_dir = examples/SettingsInCustomClass
 ; src_dir = examples/Strings
-src_dir = examples/Bytestreams
+src_dir = examples/Utilities
 
 [env:esp32-s3]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip
-; platform = espressif32@6.5.0
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 framework = arduino
 
 ; Tests
-; Ignore Unity library to avoid conflicts with source code due to lib_dir = .
+; Ignore Unity library to avoid scanning .pio/libdeps/Unity/examples/ as part of lib_dir = .
+; Add Unity src path manually so unity.h is still found during test compilation
 lib_ignore = Unity
 
 ; Config ESP32
@@ -45,6 +51,9 @@ build_flags =
   -Wall
   -Wextra
   -Werror
+
+  ; Unity include path (lib_ignore = Unity prevents it from being auto-added)
+  -I.pio/libdeps/esp32-s3/Unity/src
 
   ; Enable debug (ESP-IDF logs)
   ; -DUSE_ESP_IDF_LOG

--- a/src/SettingsManagerESP32.cpp
+++ b/src/SettingsManagerESP32.cpp
@@ -50,10 +50,17 @@ bool deinit(const char* partition_name) {
 bool erase(const char* partition_name) {
   if (!_initialized) return false;
 
+  bool success;
+
   if (partition_name) {
-    return (nvs_flash_erase_partition(partition_name) == ESP_OK);
+    success = (nvs_flash_erase_partition(partition_name) == ESP_OK);
+  } else {
+    success = (nvs_flash_erase() == ESP_OK);
   }
-  return (nvs_flash_erase() == ESP_OK);
+
+  // nvs_flash_erase() implicitly deinitializes the partition
+  if (success) _initialized = false;
+  return success;
 }
 
 const char* typeToStr(const NVS::Type t) {

--- a/src/SettingsManagerESP32.cpp
+++ b/src/SettingsManagerESP32.cpp
@@ -63,6 +63,14 @@ bool erase(const char* partition_name) {
   return success;
 }
 
+bool getStats(nvs_stats_t& stats, const char* partition_name) {
+  if (partition_name) {
+    return (nvs_get_stats(partition_name, &stats) == ESP_OK);
+  } else {
+    return (nvs_get_stats(nullptr, &stats) == ESP_OK);
+  }
+}
+
 const char* typeToStr(const NVS::Type t) {
   switch (t) {
     case NVS::Type::Bool: return "Bool";

--- a/src/SettingsManagerESP32.cpp
+++ b/src/SettingsManagerESP32.cpp
@@ -1,9 +1,153 @@
 /**
- * SPDX-FileCopyrightText: 2025 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
 
 #include "SettingsManagerESP32.h"
 
-Preferences nvs;
+#include <nvs_flash.h>
+#include <string.h>
+
+namespace NVS {
+
+static bool _initialized = false;
+
+bool init(const char* partition_name) {
+  if (_initialized) return true;
+
+  bool success = false;
+
+  if (partition_name) {
+    success = (nvs_flash_init_partition(partition_name) == ESP_OK);
+  } else {
+    success = (nvs_flash_init() == ESP_OK);
+  }
+
+  if (!success) return false;
+
+  _initialized = true;
+  return true;
+}
+
+bool deinit(const char* partition_name) {
+  if (!_initialized) return true;
+
+  bool success = false;
+
+  if (partition_name) {
+    success = (nvs_flash_deinit_partition(partition_name) == ESP_OK);
+  } else {
+    success = (nvs_flash_deinit() == ESP_OK);
+  }
+
+  if (!success) return false;
+
+  _initialized = false;
+  return true;
+}
+
+bool erase(const char* partition_name) {
+  if (!_initialized) return false;
+
+  if (partition_name) {
+    return (nvs_flash_erase_partition(partition_name) == ESP_OK);
+  }
+  return (nvs_flash_erase() == ESP_OK);
+}
+
+const char* typeToStr(const NVS::Type t) {
+  switch (t) {
+    case NVS::Type::Bool: return "Bool";
+    case NVS::Type::UInt32: return "UInt32";
+    case NVS::Type::Int32: return "Int32";
+    case NVS::Type::Float: return "Float";
+    case NVS::Type::Double: return "Double";
+    case NVS::Type::String: return "String";
+    case NVS::Type::ByteStream: return "ByteStream";
+    default: return "Unknown";
+  }
+}
+
+bool fromHexToStr(const NVS::ByteStreamView bs, char* buf, const size_t buf_size,
+                  const bool with_spaces) {
+  if (!bs.data || buf_size < hexStrSize(bs.size, with_spaces)) return false;
+
+  static const char HEX_CHARS[] = "0123456789ABCDEF";
+
+  for (size_t i = 0; i < bs.size; i++) {
+    size_t pos   = with_spaces ? i * 3 : i * 2;
+    buf[pos]     = HEX_CHARS[bs.data[i] >> 4];
+    buf[pos + 1] = HEX_CHARS[bs.data[i] & 0x0F];
+    if (with_spaces && i < bs.size - 1) buf[pos + 2] = ' ';
+  }
+
+  buf[with_spaces ? bs.size * 3 - 1 : bs.size * 2] = '\0';
+  return true;
+}
+
+bool fromStrToHex(const char* hex, NVS::ByteStream& out, const bool with_spaces) {
+  if (!hex || !out.data) return false;
+
+  size_t len = strlen(hex);
+  size_t byte_count;
+
+  if (with_spaces) {
+    if (len == 0) {
+      out.size = 0;
+      return true;
+    }
+    if ((len + 1) % 3 != 0) return false;
+    byte_count = (len + 1) / 3;
+  } else {
+    if (len % 2 != 0) return false;
+    byte_count = len / 2;
+  }
+
+  if (byte_count > out.max_size) return false;
+
+  for (size_t i = 0; i < byte_count; i++) {
+    size_t pos = with_spaces ? i * 3 : i * 2;
+    uint8_t high, low;
+    char c = hex[pos];
+
+    if (c >= '0' && c <= '9')
+      high = c - '0';
+    else if (c >= 'A' && c <= 'F')
+      high = c - 'A' + 10;
+    else if (c >= 'a' && c <= 'f')
+      high = c - 'a' + 10;
+    else
+      return false;
+
+    c = hex[pos + 1];
+
+    if (c >= '0' && c <= '9')
+      low = c - '0';
+    else if (c >= 'A' && c <= 'F')
+      low = c - 'A' + 10;
+    else if (c >= 'a' && c <= 'f')
+      low = c - 'a' + 10;
+    else
+      return false;
+
+    if (with_spaces && i < byte_count - 1 && hex[pos + 2] != ' ') return false;
+
+    out.data[i] = (high << 4) | low;
+  }
+
+  out.size = byte_count;
+  return true;
+}
+
+const char* formatToStr(const NVS::ByteStream::Format f) {
+  switch (f) {
+    case NVS::ByteStream::Format::Hex: return "Hex";
+    case NVS::ByteStream::Format::Base64: return "Base64";
+    case NVS::ByteStream::Format::JSONObject: return "JSONObject";
+    case NVS::ByteStream::Format::JSONArray: return "JSONArray";
+    default: return "Unknown";
+  }
+}
+
+} // namespace NVS

--- a/src/SettingsManagerESP32.h
+++ b/src/SettingsManagerESP32.h
@@ -1,746 +1,162 @@
 /**
- * SPDX-FileCopyrightText: 2025 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
-#include <Arduino.h>
-#include <Preferences.h>
-#include <array>
-#include <initializer_list>
+#include "internal/ISettings.h"
+#include "internal/Policy.h"
+#include "internal/Setting.h"
+#include "internal/Settings.h"
+#include "internal/Types.h"
 
-#ifndef SETTINGS_STRING_BUFFER_SIZE
-#define SETTINGS_STRING_BUFFER_SIZE 32
-#endif
+/* ---------------------------------- X-macro expansion helpers --------------------------------- */
 
-#ifndef SETTINGS_BYTE_STREAM_BUFFER_SIZE
-#define SETTINGS_BYTE_STREAM_BUFFER_SIZE 32
-#endif
-
-// X-macros
+// Expands one X-macro entry into an enum class enumerator
 #define SETTINGS_EXPAND_ENUM_CLASS(name, text, value, formattable) name,
-#define SETTINGS_EXPAND_SETTINGS(name, text, value, formattable)   {#name, text, value, formattable},
-#define SETTINGS_ADD_ELEMENT(...)                                  +1
 
-// Macro to count the number of elements in a X-Macro list
+// Expands one X-macro entry into a NVS::Internal::Setting initializer
+#define SETTINGS_EXPAND_SETTINGS(name, text, value, formattable) {#name, text, value, formattable},
+
+// Counts one X-macro entry (used internally by SETTINGS_COUNT)
+#define SETTINGS_ADD_ELEMENT(...) +1
+
+/**
+ * @brief Counts the number of entries in an X-macro list.
+ *
+ * Usage: `SETTINGS_COUNT(MY_SETTINGS_MACRO)`
+ */
 #define SETTINGS_COUNT(settings_macro) (0 settings_macro(SETTINGS_ADD_ELEMENT))
 
-// NVS (non-volatile storage ESP32)
-extern Preferences nvs;
+/* --------------------------------- Convenience creation macros -------------------------------- */
+
+/**
+ * Each macro declares an enum class and a matching NVS::Settings<> object in one step.
+ * The object is named st_<name> and must be opened with st_<name>.begin() after NVS::init().
+ *
+ * Parameters:
+ * - name           : identifier used for the enum class and the st_<name> object
+ * - ns             : NVS namespace string (max 15 chars)
+ * - settings_macro : X-macro list macro
+ */
+
+#define SETTINGS_CREATE_BOOLS(name, ns, settings_macro)                     \
+  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
+  NVS::Settings<bool, name, SETTINGS_COUNT(settings_macro)> st_##name(      \
+    ns, {settings_macro(SETTINGS_EXPAND_SETTINGS)});
+
+#define SETTINGS_CREATE_UINT32S(name, ns, settings_macro)                   \
+  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
+  NVS::Settings<uint32_t, name, SETTINGS_COUNT(settings_macro)> st_##name(  \
+    ns, {settings_macro(SETTINGS_EXPAND_SETTINGS)});
+
+#define SETTINGS_CREATE_INT32S(name, ns, settings_macro)                    \
+  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
+  NVS::Settings<int32_t, name, SETTINGS_COUNT(settings_macro)> st_##name(   \
+    ns, {settings_macro(SETTINGS_EXPAND_SETTINGS)});
+
+#define SETTINGS_CREATE_FLOATS(name, ns, settings_macro)                    \
+  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
+  NVS::Settings<float, name, SETTINGS_COUNT(settings_macro)> st_##name(     \
+    ns, {settings_macro(SETTINGS_EXPAND_SETTINGS)});
+
+#define SETTINGS_CREATE_DOUBLES(name, ns, settings_macro)                   \
+  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
+  NVS::Settings<double, name, SETTINGS_COUNT(settings_macro)> st_##name(    \
+    ns, {settings_macro(SETTINGS_EXPAND_SETTINGS)});
+
+#define SETTINGS_CREATE_STRINGS(name, ns, settings_macro)                   \
+  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
+  NVS::Settings<NVS::Str, name, SETTINGS_COUNT(settings_macro)> st_##name(  \
+    ns, {settings_macro(SETTINGS_EXPAND_SETTINGS)});
+
+#define SETTINGS_CREATE_BYTE_STREAMS(name, ns, settings_macro)                    \
+  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) };       \
+  NVS::Settings<NVS::ByteStream, name, SETTINGS_COUNT(settings_macro)> st_##name( \
+    ns, {settings_macro(SETTINGS_EXPAND_SETTINGS)});
+
+/* ----------------------------------- NVS partition lifecycle ---------------------------------- */
 
 namespace NVS {
 
-// Type of Setting object. Useful when using pointers.
-enum class Type : uint8_t { Bool, UInt32, Int32, Float, Double, String, ByteStream };
+/**
+ * @brief Initialize the default NVS flash partition. Call once in `setup()` before any `begin()`.
+ * @param partition_name Optional custom partition name. If `nullptr`, the default partition is
+ * used.
+ * @return Initialized successfully or already initialized, false otherwise.
+ */
+bool init(const char* partition_name = nullptr);
 
-// Byte Stream struct, useful for binary data (blob)
-struct ByteStream {
-  const uint8_t* data;
-  size_t size;
-  enum class Format : uint8_t { Hex, Base64, JSONObject, JSONArray } format;
+/**
+ * @brief Deinitialize the default NVS flash partition.
+ * @param partition_name Optional custom partition name. If `nullptr`, the default partition is
+ * used.
+ * @return Deinitialized successfully or already deinitialized, false otherwise.
+ */
+bool deinit(const char* partition_name = nullptr);
 
-  // Default constructor
-  constexpr ByteStream(const uint8_t* d = nullptr, size_t s = 0, Format f = Format::Hex)
-      : data(d)
-      , size(s)
-      , format(f) {}
-};
+/**
+ * @brief Erase the entire default NVS flash partition. All namespaces and keys are lost. After
+ * calling this, you must call `init()` again before using any Settings objects.
+ * @param partition_name Optional custom partition name. If `nullptr`, the default partition is
+ * used.
+ * @return Erased successfully, false otherwise.
+ */
+bool erase(const char* partition_name = nullptr);
 
-namespace Internal {
-// Different type of settings to save in NVS
-template <typename T>
-struct Setting {
-  const char* key;
-  const char* hint;
-  T default_value;
-  bool formattable;
-};
+/* ------------------------------------------ Utilities ----------------------------------------- */
 
-// Policy types
-template <typename T>
-class Policy {
-  public:
-  virtual bool setValue(const char* key, T value)      = 0;
-  virtual T getValue(const char* key, T default_value) = 0;
-};
+/**
+ * @brief Convert a `NVS::Type` enum value to a string representation.
+ * @param t `NVS::Type` value.
+ * @return A string representation of the type.
+ */
+const char* typeToStr(const NVS::Type t);
 
-// Policy for bool
-class BoolPolicy : public Policy<bool> {
-  public:
-  bool setValue(const char* key, bool value) { return (nvs.putBool(key, value) == sizeof(bool)); }
-
-  bool getValue(const char* key, bool default_value) { return nvs.getBool(key, default_value); }
-};
-
-// Policy for uint32_t
-class UInt32Policy : public Policy<uint32_t> {
-  public:
-  bool setValue(const char* key, uint32_t value) {
-    return (nvs.putUInt(key, value) == sizeof(uint32_t));
-  }
-
-  uint32_t getValue(const char* key, uint32_t default_value) {
-    return nvs.getUInt(key, default_value);
-  }
-};
-
-// Policy for int32_t
-class Int32Policy : public Policy<int32_t> {
-  public:
-  bool setValue(const char* key, int32_t value) {
-    return (nvs.putInt(key, value) == sizeof(int32_t));
-  }
-
-  int32_t getValue(const char* key, int32_t default_value) {
-    return nvs.getInt(key, default_value);
-  }
-};
-
-// Policy for float
-class FloatPolicy : public Policy<float> {
-  public:
-  bool setValue(const char* key, float value) {
-    return (nvs.putFloat(key, value)) == sizeof(float);
-  }
-
-  float getValue(const char* key, float default_value) { return nvs.getFloat(key, default_value); }
-};
-
-// Policy for double
-class DoublePolicy : public Policy<double> {
-  public:
-  bool setValue(const char* key, double value) {
-    return (nvs.putDouble(key, value) == sizeof(double));
-  }
-  double getValue(const char* key, double default_value) {
-    return nvs.getDouble(key, default_value);
-  }
-};
-
-// Policy for string
-class StringPolicy : public Policy<const char*> {
-  public:
-  StringPolicy() { _mutex = xSemaphoreCreateMutexStatic(&_mutex_buf); }
-
-  bool setValue(const char* key, const char* value) {
-    return (nvs.putString(key, value) == strlen(value));
-  }
-
-  const char* getValue(const char* key, const char* default_value) {
-    xSemaphoreTake(_mutex, portMAX_DELAY);
-    size_t len = nvs.getString(key, _buffer, sizeof(_buffer));
-    return (len > 0 ? _buffer : default_value);
-  }
-
-  void giveMutex() { xSemaphoreGive(_mutex); }
-
-  private:
-  char _buffer[SETTINGS_STRING_BUFFER_SIZE];
-  SemaphoreHandle_t _mutex;
-  StaticSemaphore_t _mutex_buf;
-};
-
-// Policy for Byte Streams
-class ByteStreamPolicy : public Policy<ByteStream> {
-  public:
-  ByteStreamPolicy() { _mutex = xSemaphoreCreateMutexStatic(&_mutex_buf); }
-
-  bool setValue(const char* key, const ByteStream value) {
-    return (nvs.putBytes(key, value.data, value.size) == value.size);
-  }
-
-  ByteStream getValue(const char* key, ByteStream default_value) {
-    xSemaphoreTake(_mutex, portMAX_DELAY);
-    size_t len = nvs.getBytes(key, _buffer, sizeof(_buffer));
-    return (len > 0 ? ByteStream{_buffer, len, default_value.format} : default_value);
-  }
-
-  void giveMutex() { xSemaphoreGive(_mutex); }
-
-  private:
-  uint8_t _buffer[SETTINGS_BYTE_STREAM_BUFFER_SIZE];
-  SemaphoreHandle_t _mutex;
-  StaticSemaphore_t _mutex_buf;
-};
-
-// Type trait to map types to policies
-template <typename T>
-struct PolicyTrait {};
-
-template <>
-struct PolicyTrait<bool> {
-  static const Type enum_type = Type::Bool;
-  using policy_type           = BoolPolicy;
-  using struct_type           = Setting<bool>;
-};
-
-template <>
-struct PolicyTrait<uint32_t> {
-  static const Type enum_type = Type::UInt32;
-  using policy_type           = UInt32Policy;
-  using struct_type           = Setting<uint32_t>;
-};
-
-template <>
-struct PolicyTrait<int32_t> {
-  static const Type enum_type = Type::Int32;
-  using policy_type           = Int32Policy;
-  using struct_type           = Setting<int32_t>;
-};
-
-template <>
-struct PolicyTrait<float> {
-  static const Type enum_type = Type::Float;
-  using policy_type           = FloatPolicy;
-  using struct_type           = Setting<float>;
-};
-
-template <>
-struct PolicyTrait<double> {
-  static const Type enum_type = Type::Double;
-  using policy_type           = DoublePolicy;
-  using struct_type           = Setting<double>;
-};
-
-template <>
-struct PolicyTrait<const char*> {
-  static const Type enum_type = Type::String;
-  using policy_type           = StringPolicy;
-  using struct_type           = Setting<const char*>;
-};
-
-template <>
-struct PolicyTrait<ByteStream> {
-  static const Type enum_type = Type::ByteStream;
-  using policy_type           = ByteStreamPolicy;
-  using struct_type           = Setting<ByteStream>;
-};
-} // namespace Internal
-
-// Interface for Settings objects, useful when using pointers.
-class ISettings {
-  public:
-  using GlobalOnChangeCb = typename std::function<void(
-    const char* key, const Type type, const size_t index, const void* updated_value)>;
-
-  /**
-   * @brief Get the Type of the object.
-   * @return Type Enum
-   */
-  virtual Type getType() = 0;
-
-  /**
-   * @brief Get the size of the setting object.
-   * @return size_t Number of settings
-   */
-  virtual size_t getSize() = 0;
-
-  /**
-   * @brief Get a key string.
-   * @param index Index in the list
-   * @return const char* Key string, nullptr if out of bounds
-   */
-  virtual const char* getKey(size_t index) = 0;
-
-  /**
-   * @brief Get a hint string.
-   * @param index Index in the list
-   * @return const char* Hint string, nullptr if out of bounds
-   */
-  virtual const char* getHint(size_t index) = 0;
-
-  /**
-   * @brief Get a pointer to the default value. You need to cast it back to the correct type.
-   * @param index Index in the list
-   * @return const void* Pointer to the default value, nullptr if out of bounds
-   */
-  virtual const void* getDefaultValuePtr(size_t index) = 0;
-
-  /**
-   * @brief Get a default value casted to type passed as template parameter.
-   * @tparam T Type to cast the value
-   * @param index Index in the list
-   * @return T Setting default value, or a default value of the type if out of bounds
-   */
-  template <typename T>
-  T getDefaultValueAs(size_t index) {
-    if (index >= getSize()) return T();
-    return *(static_cast<const T*>(getDefaultValuePtr(index)));
-  }
-
-  /**
-   * @brief Set a new value via pointer.
-   * @param index Index in the list
-   * @param value New value to store
-   * @return true OK
-   * @return false Failed to save or index out of bounds
-   */
-  virtual bool setValuePtr(size_t index, const void* value) = 0;
-
-  /**
-   * @brief Get a copy of the value stored in NVS via pointer.
-   * @param index Index in the list
-   * @param value Pointer to a variable to store a copy of a NVS stored value
-   * @param size Size of the variable
-   * @return true OK
-   * @return false Failed to retrieve or index out of bounds
-   */
-  virtual bool getValuePtr(size_t index, void* value, size_t size) = 0;
-
-  /**
-   * @brief Give the mutex after using the method getValue() for const char* and ByteStream types.
-   * Not needed for other types.
-   */
-  virtual void giveMutex() = 0;
-
-  /**
-   * @brief Set a global callback for all the settings of the object. This callback will be called
-   * when a setting is changed.
-   * @param callback Callback function
-   * @param callable_on_format If the callback should be called when the setting is formatted
-   */
-  virtual void setGlobalOnChangeCallback(GlobalOnChangeCb callback, bool callable_on_format) = 0;
-
-  /**
-   * @brief Clear the global callback for all the settings of the object.
-   */
-  virtual void clearGlobalOnChangeCallback() = 0;
-
-  /**
-   * @brief Check if a key exists in the list.
-   * @param key Key string
-   * @param index_found Index of the key found
-   * @return true Key found
-   * @return false Key not found
-   */
-  virtual bool hasKey(const char* key, size_t& index_found) = 0;
-
-  /**
-   * @brief Check if a setting is formattable.
-   * @param index Index in the list
-   * @return true Formattable
-   * @return false Not formattable or index out of bounds
-   */
-  virtual bool isFormattable(size_t index) = 0;
-
-  /**
-   * @brief Format a setting to its default value.
-   * @param index Index in the list
-   * @param force Force the format even if the setting is not formattable
-   * @return true OK
-   * @return false Failed to format or index out of bounds
-   */
-  virtual bool format(size_t index, bool force = false) = 0;
-
-  /**
-   * @brief Format all settings to their default values.
-   * @param force Force the format even if the setting is not formattable
-   * @return size_t Number of errors while trying to format
-   */
-  virtual size_t formatAll(bool force = false) = 0;
-};
-
-// Template specialization for const char* (strings)
-template <>
-inline const char* ISettings::getDefaultValueAs<const char*>(size_t index) {
-  if (index >= getSize()) return nullptr;
-  return static_cast<const char*>(getDefaultValuePtr(index));
+/**
+ * @brief Calculate the buffer size required by `hexStrSize()` for a given number of bytes.
+ * @param byte_count Number of bytes to encode.
+ * @param with_spaces Whether spaces will be inserted between bytes (e.g. `"DE AD BE EF"`).
+ * @return Required buffer size in bytes, including the null terminator.
+ */
+constexpr size_t hexStrSize(const size_t byte_count, const bool with_spaces = false) {
+  if (byte_count == 0) return 1;
+  return with_spaces ? byte_count * 3 : byte_count * 2 + 1;
 }
 
 /**
- * @brief Main class for setting management. Use this class to create a new setting object of the
- * selected type with its respective enum class.
- *
- * @tparam T Type of the setting
- * @tparam ENUM Enum class with all the settings
- * @tparam N Number of settings in the list
+ * @brief Encode a `ByteStreamView` as a null-terminated hex string into a caller-provided buffer.
+ * @param bs The byte data to encode.
+ * @param buf Output buffer. Must hold at least `hexStrSize(bs.size, with_spaces)` bytes.
+ * @param buf_size Size of the output buffer in bytes.
+ * @param with_spaces If `true`, bytes are separated by spaces (e.g. `"DE AD BE EF"`). If `false`,
+ * bytes are concatenated (e.g. `"DEADBEEF"`).
+ * @retval `true` Encoded successfully.
+ * @retval `false` Buffer too small or `bs.data` is null.
  */
-template <typename T, typename ENUM, size_t N>
-class Settings : public ISettings {
-  public:
-  using Policy = typename Internal::PolicyTrait<T>::policy_type;
-  using Struct = typename Internal::PolicyTrait<T>::struct_type;
-  using OnChangeCb =
-    typename std::function<void(const char* key, const ENUM setting, const T updated_value)>;
+bool fromHexToStr(const NVS::ByteStreamView bs, char* buf, const size_t buf_size,
+                  const bool with_spaces = false);
 
-  Settings(std::initializer_list<Struct> list)
-      : _global_on_change_cb(nullptr)
-      , _global_on_change_cb_callable_on_format(false) {
-    _on_change_cbs.fill(nullptr);
-    _on_change_cbs_callable_on_format.fill(false);
-    std::copy_n(list.begin(), N, _list.begin());
-  }
+/**
+ * @brief Decode a hex string into a `ByteStream` buffer.
+ * @param hex Null-terminated hex string. With `with_spaces = false`, must have even length (e.g.
+ * `"DEADBEEF"`). With `with_spaces = true`, bytes must be separated by single spaces
+ * (e.g. `"DE AD BE EF"`).
+ * @param out Destination `ByteStream`. `out.data` must point to a buffer large enough to hold the
+ * decoded bytes. On success, `out.size` is updated.
+ * @param with_spaces Whether the input string uses space-separated bytes.
+ * @retval `true` Decoded successfully.
+ * @retval `false` Invalid hex characters, malformed string, or buffer too small.
+ */
+bool fromStrToHex(const char* hex, NVS::ByteStream& out, const bool with_spaces = false);
 
-  Type getType() override { return Internal::PolicyTrait<T>::enum_type; }
+/**
+ * @brief Convert a `ByteStream::Format` enum value to a string representation.
+ * @param f The `ByteStream::Format` value.
+ * @return A string representation of the format.
+ */
+const char* formatToStr(const NVS::ByteStream::Format f);
 
-  size_t getSize() override { return _list.size(); }
-
-  /**
-   * @brief Get a key string.
-   * @param index Index in the list
-   * @return const char* Key string, nullptr if out of bounds
-   */
-  const char* getKey(size_t index) override {
-    if (index >= getSize()) return nullptr;
-    return _list[index].key;
-  }
-
-  /**
-   * @brief Get a hint string.
-   * @param index Index in the list
-   * @return const char* Hint string, nullptr if out of bounds
-   */
-  const char* getHint(size_t index) override {
-    if (index >= getSize()) return nullptr;
-    return _list[index].hint;
-  }
-
-  /**
-   * @brief Get a pointer to the default value. You need to cast it back to the correct type.
-   * @param index Index in the list
-   * @return const void* Pointer to the default value, nullptr if out of bounds
-   */
-  const void* getDefaultValuePtr(size_t index) override {
-    if (index >= getSize()) return nullptr;
-    return getDefaultValuePtrImpl(index, std::is_same<T, const char*>());
-  }
-
-  /**
-   * @brief Set a new value via pointer.
-   * @param index Index in the list
-   * @param value New value to store
-   * @return true OK
-   * @return false Failed to save or index out of bounds
-   */
-  bool setValuePtr(size_t index, const void* value) override {
-    if (index >= getSize()) return false;
-    return setValuePtrImpl(index, value, std::is_same<T, const char*>());
-  }
-
-  /**
-   * @brief Get a copy of the value stored in NVS via pointer.
-   * @param index Index in the list
-   * @param value Pointer to a variable to store a copy of a NVS stored value
-   * @param size Size of the variable
-   * @return true OK
-   * @return false Failed to retrieve or index out of bounds
-   */
-  bool getValuePtr(size_t index, void* value, size_t size) override {
-    if (index >= getSize()) return false;
-    return getValuePtrImpl(index, value, size, std::is_same<T, const char*>());
-  }
-
-  /**
-   * @brief Set a global callback for all the settings of the object. This callback will be called
-   * when a setting is changed.
-   * @param callback Callback function
-   * @param callable_on_format If the callback should be called when the setting is formatted
-   */
-  void setGlobalOnChangeCallback(GlobalOnChangeCb callback, bool callable_on_format) override {
-    _global_on_change_cb                    = callback;
-    _global_on_change_cb_callable_on_format = callable_on_format;
-  }
-
-  /**
-   * @brief Clear the global callback for all the settings of the object.
-   */
-  void clearGlobalOnChangeCallback() override {
-    _global_on_change_cb                    = nullptr;
-    _global_on_change_cb_callable_on_format = false;
-  }
-
-  /**
-   * @brief Check if a key exists in the list.
-   * @param key Key string
-   * @param index_found Index of the key found
-   * @return true Key found
-   * @return false Key not found
-   */
-  bool hasKey(const char* key, size_t& index_found) override {
-    for (size_t i = 0; i < getSize(); i++) {
-      if (strcmp(_list[i].key, key) == 0) {
-        index_found = i;
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * @brief Check if a setting is formattable.
-   * @param index Index in the list
-   * @return true Formattable
-   * @return false Not formattable or index out of bounds
-   */
-  bool isFormattable(size_t index) override {
-    if (index >= getSize()) return false;
-    return _list[index].formattable;
-  }
-
-  /**
-   * @brief Format a setting to its default value.
-   * @param index Index in the list
-   * @param force Force the format even if the setting is not formattable
-   * @return true OK
-   * @return false Failed to format or index out of bounds
-   */
-  bool format(size_t index, bool force = false) override {
-    if (index >= getSize()) return false;
-
-    if (!isFormattable(index) && !force) return false;
-
-    return setValueImpl(static_cast<ENUM>(index), getDefaultValue(index), true);
-  }
-
-  /**
-   * @brief Format all settings to their default values.
-   * @param force Force the format even if the setting is not formattable
-   * @return size_t Number of errors while trying to format
-   */
-  size_t formatAll(bool force = false) override {
-    size_t errors = 0;
-
-    for (size_t i = 0; i < getSize(); i++) {
-      if (!isFormattable(i) && !force) continue;
-
-      if (!setValueImpl(static_cast<ENUM>(i), getDefaultValue(i), true)) errors++;
-    }
-
-    return errors;
-  }
-
-  /**
-   * @brief Format a setting to its default value.
-   * @param ENUM Selected setting
-   * @param force Force the format even if the setting is not formattable
-   * @return true OK
-   * @return false Failed to format
-   */
-  bool format(ENUM setting, bool force = false) {
-    return format(static_cast<size_t>(setting), force);
-  }
-
-  /**
-   * @brief Get a key string.
-   * @param index Index in the list
-   * @return const char* Key string
-   */
-  const char* getKey(ENUM setting) { return _list[static_cast<size_t>(setting)].key; }
-
-  /**
-   * @brief Get a hint string.
-   * @param index Index in the list
-   * @return const char* Hint string
-   */
-  const char* getHint(ENUM setting) { return _list[static_cast<size_t>(setting)].hint; }
-
-  /**
-   * @brief Get a default value.
-   * @param index Index in the list
-   * @return T Setting default value or a default value of the type if out of bounds
-   */
-  T getDefaultValue(size_t index) {
-    if (index >= getSize()) return T();
-    return _list[index].default_value;
-  }
-
-  /**
-   * @brief Get a default value.
-   * @param ENUM Selected setting
-   * @return T Setting default value
-   */
-  T getDefaultValue(ENUM setting) { return _list[static_cast<size_t>(setting)].default_value; }
-
-  /**
-   * @brief Set a new value.
-   * @param ENUM Selected setting
-   * @param value New value to store
-   * @return true OK
-   * @return false Failed to save
-   */
-  bool setValue(ENUM setting, const T value) { return setValueImpl(setting, value, false); }
-
-  /**
-   * @brief Get a current value stored in NVS.
-   * @param ENUM Selected setting
-   * @return T Current value
-   */
-  T getValue(ENUM setting) {
-    return _policy.getValue(getKey(static_cast<size_t>(setting)), getDefaultValue(setting));
-  }
-
-  /**
-   * @brief Set a callback for a specific setting.
-   * @param ENUM Selected setting
-   * @param callback Callback function
-   * @param callable_on_format If the callback should be called when the setting is formatted
-   */
-  void setOnChangeCallback(ENUM setting, OnChangeCb callback, bool callable_on_format) {
-    _on_change_cbs[static_cast<size_t>(setting)]                    = callback;
-    _on_change_cbs_callable_on_format[static_cast<size_t>(setting)] = callable_on_format;
-  }
-
-  /**
-   * @brief Clear the callback for a specific setting.
-   * @param ENUM Selected setting
-   */
-  void clearOnChangeCallback(ENUM setting) {
-    _on_change_cbs[static_cast<size_t>(setting)]                    = nullptr;
-    _on_change_cbs_callable_on_format[static_cast<size_t>(setting)] = false;
-  }
-
-  /**
-   * @brief Check if a setting is formattable.
-   * @param ENUM Selected setting
-   * @return true Formattable
-   * @return false Not formattable
-   */
-  bool isFormattable(ENUM setting) { return _list[static_cast<size_t>(setting)].formattable; }
-
-  /**
-   * @brief Give the mutex after using the method getValue() for const char* and ByteStream types.
-   * Not needed for other types.
-   */
-  void giveMutex() override { giveMutexImpl(); }
-
-  private:
-  GlobalOnChangeCb _global_on_change_cb;
-  bool _global_on_change_cb_callable_on_format;
-
-  std::array<OnChangeCb, N> _on_change_cbs;
-  std::array<bool, N> _on_change_cbs_callable_on_format;
-
-  std::array<Struct, N> _list;
-
-  Policy _policy;
-
-  bool setValueImpl(ENUM setting, const T value, bool called_from_format) {
-    size_t index = static_cast<size_t>(setting);
-
-    if (!_policy.setValue(getKey(index), value)) return false;
-
-    bool should_call_global_callback =
-      called_from_format ? _global_on_change_cb_callable_on_format : true;
-
-    bool should_call_local_callback =
-      called_from_format ? _on_change_cbs_callable_on_format[index] : true;
-
-    if (should_call_global_callback && _global_on_change_cb) {
-      runGlobalCallback(getKey(setting), getType(), index, value, std::is_same<T, const char*>());
-    }
-
-    if (should_call_local_callback && _on_change_cbs[index]) {
-      _on_change_cbs[index](getKey(setting), setting, value);
-    }
-
-    return true;
-  }
-
-  // Template specializations for const char* (strings)
-  template <typename U = T>
-  const void* getDefaultValuePtrImpl(size_t index, std::true_type) {
-    return static_cast<const void*>(_list[index].default_value);
-  }
-
-  template <typename U = T>
-  bool setValuePtrImpl(size_t index, const void* value, std::true_type) {
-    return setValueImpl(static_cast<ENUM>(index), static_cast<U>(value), false);
-  }
-
-  template <typename U = T>
-  bool getValuePtrImpl(size_t index, void* value, size_t size, std::true_type) {
-    const char* temp = getValue(static_cast<ENUM>(index));
-    size_t len       = strlen(temp);
-
-    if (size < len + 1) return false;
-
-    strncpy(static_cast<char*>(value), temp, len);
-    static_cast<char*>(value)[len] = '\0';
-    return true;
-  }
-
-  template <typename U = T>
-  void runGlobalCallback(const char* key, Type type, size_t index, U value, std::true_type) {
-    _global_on_change_cb(key, type, index, value);
-  }
-
-  // Template specializations for all other types
-  template <typename U = T>
-  const void* getDefaultValuePtrImpl(size_t index, std::false_type) {
-    return static_cast<const void*>(&(_list[index].default_value));
-  }
-
-  template <typename U = T>
-  bool setValuePtrImpl(size_t index, const void* value, std::false_type) {
-    return setValueImpl(static_cast<ENUM>(index), *static_cast<const U*>(value), false);
-  }
-
-  template <typename U = T>
-  bool getValuePtrImpl(size_t index, void* value, size_t size, std::false_type) {
-    U temp = getValue(static_cast<ENUM>(index));
-
-    if (size < sizeof(U)) return false;
-
-    memcpy(value, &temp, sizeof(U));
-    return true;
-  }
-
-  // Implementation for const char* and ByteStream types
-  template <typename U = T>
-  typename std::enable_if<std::is_same<U, const char*>::value ||
-                          std::is_same<U, ByteStream>::value>::type
-  giveMutexImpl() {
-    _policy.giveMutex();
-  }
-
-  // Empty implementation for all other types
-  template <typename U = T>
-  typename std::enable_if<!(std::is_same<U, const char*>::value ||
-                            std::is_same<U, ByteStream>::value)>::type
-  giveMutexImpl() {}
-
-  template <typename U = T>
-  void runGlobalCallback(const char* key, Type type, size_t index, U value, std::false_type) {
-    _global_on_change_cb(key, type, index, &value);
-  }
-};
 } // namespace NVS
-
-// Macros to create settings's enum class and object list with a single line
-#define SETTINGS_CREATE_BOOLS(name, settings_macro)                         \
-  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
-  NVS::Settings<bool, name, SETTINGS_COUNT(settings_macro)> st_##name = {   \
-    settings_macro(SETTINGS_EXPAND_SETTINGS)};
-
-#define SETTINGS_CREATE_UINT32S(name, settings_macro)                         \
-  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) };   \
-  NVS::Settings<uint32_t, name, SETTINGS_COUNT(settings_macro)> st_##name = { \
-    settings_macro(SETTINGS_EXPAND_SETTINGS)};
-
-#define SETTINGS_CREATE_INT32S(name, settings_macro)                         \
-  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) };  \
-  NVS::Settings<int32_t, name, SETTINGS_COUNT(settings_macro)> st_##name = { \
-    settings_macro(SETTINGS_EXPAND_SETTINGS)};
-
-#define SETTINGS_CREATE_FLOATS(name, settings_macro)                        \
-  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
-  NVS::Settings<float, name, SETTINGS_COUNT(settings_macro)> st_##name = {  \
-    settings_macro(SETTINGS_EXPAND_SETTINGS)};
-
-#define SETTINGS_CREATE_DOUBLES(name, settings_macro)                       \
-  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) }; \
-  NVS::Settings<double, name, SETTINGS_COUNT(settings_macro)> st_##name = { \
-    settings_macro(SETTINGS_EXPAND_SETTINGS)};
-
-#define SETTINGS_CREATE_STRINGS(name, settings_macro)                            \
-  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) };      \
-  NVS::Settings<const char*, name, SETTINGS_COUNT(settings_macro)> st_##name = { \
-    settings_macro(SETTINGS_EXPAND_SETTINGS)};
-
-#define SETTINGS_CREATE_BYTE_STREAMS(name, settings_macro)                           \
-  enum class name : uint8_t { settings_macro(SETTINGS_EXPAND_ENUM_CLASS) };          \
-  NVS::Settings<NVS::ByteStream, name, SETTINGS_COUNT(settings_macro)> st_##name = { \
-    settings_macro(SETTINGS_EXPAND_SETTINGS)};

--- a/src/SettingsManagerESP32.h
+++ b/src/SettingsManagerESP32.h
@@ -109,6 +109,16 @@ bool erase(const char* partition_name = nullptr);
 /* ------------------------------------------ Utilities ----------------------------------------- */
 
 /**
+ * @brief Get NVS storage statistics for the default or a custom partition.
+ * @param stats Output parameter for the stats struct.
+ * @param partition_name Optional custom partition name. If `nullptr`, the default partition is
+ * used.
+ * @retval `true` Stats retrieved successfully.
+ * @retval `false` Operation failed (e.g. not initialized).
+ */
+bool getStats(nvs_stats_t& stats, const char* partition_name = nullptr);
+
+/**
  * @brief Convert a `NVS::Type` enum value to a string representation.
  * @param t `NVS::Type` value.
  * @return A string representation of the type.

--- a/src/SettingsManagerESP32.h
+++ b/src/SettingsManagerESP32.h
@@ -102,6 +102,7 @@ bool deinit(const char* partition_name = nullptr);
  * calling this, you must call `init()` again before using any Settings objects.
  * @param partition_name Optional custom partition name. If `nullptr`, the default partition is
  * used.
+ * @note You need to call `end()` on all open Settings objects before erasing the partition.
  * @return Erased successfully, false otherwise.
  */
 bool erase(const char* partition_name = nullptr);

--- a/src/internal/ISettings.h
+++ b/src/internal/ISettings.h
@@ -127,10 +127,10 @@ class ISettings {
    * @param index Index in the list.
    * @param value Destination buffer.
    * @param size Size of the destination buffer in bytes.
-   * @return `const void*` Pointer to the value read from NVS, or pointer to the default value if
-   * not found in NVS or on error.
+   * @retval `true` Value read from NVS or default value.
+   * @retval `false` Handle not open, index out of bounds, or buffer too small.
    */
-  virtual const void* getValuePtrOrDefault(size_t index, void* value, size_t size) = 0;
+  virtual bool getValuePtrOrDefault(size_t index, void* value, size_t size) = 0;
 
   /**
    * @brief Register a callback that fires on every value change across this object.

--- a/src/internal/ISettings.h
+++ b/src/internal/ISettings.h
@@ -122,6 +122,17 @@ class ISettings {
   virtual bool getValuePtr(size_t index, void* value, size_t size) = 0;
 
   /**
+   * @brief Read the current NVS value into a caller-provided buffer via untyped pointer, with
+   * fallback to the default value if the key is not found in NVS.
+   * @param index Index in the list.
+   * @param value Destination buffer.
+   * @param size Size of the destination buffer in bytes.
+   * @return `const void*` Pointer to the value read from NVS, or pointer to the default value if
+   * not found in NVS or on error.
+   */
+  virtual const void* getValuePtrOrDefault(size_t index, void* value, size_t size) = 0;
+
+  /**
    * @brief Register a callback that fires on every value change across this object.
    * @param callback Callback function.
    * @param callable_on_format Whether to invoke the callback when a format operation writes a

--- a/src/internal/ISettings.h
+++ b/src/internal/ISettings.h
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <functional>
+#include <stddef.h>
+
+#include "Types.h"
+
+namespace NVS {
+
+/**
+ * @brief Type-erased interface for Settings objects. Useful for storing heterogeneous settings
+ * in arrays or passing by pointer without knowing the value type at the call site.
+ */
+class ISettings {
+  public:
+  using GlobalOnChangeCb = std::function<void(const char* key, const Type type, const size_t index,
+                                              const void* updated_value)>;
+
+  /**
+   * @brief Open the NVS namespace handle. Must be called after `NVS::init()`.
+   * @retval `true` Handle opened successfully.
+   * @retval `false` Operation failed.
+   */
+  virtual bool begin() = 0;
+
+  /**
+   * @brief Close the NVS namespace handle.
+   */
+  virtual void end() = 0;
+
+  /**
+   * @brief Get the NVS namespace string used by this Settings object.
+   * @return Namespace string.
+   */
+  virtual const char* getNamespace() const = 0;
+
+  /**
+   * @brief Check whether the NVS handle is currently open.
+   * @retval `true` Handle is open.
+   * @retval `false` Handle is closed.
+   */
+  virtual bool isOpen() const = 0;
+
+  /**
+   * @brief Erase all keys in the namespace.
+   * @retval `true` All keys erased successfully.
+   * @retval `false` Operation failed.
+   */
+  virtual bool eraseAll() = 0;
+
+  /**
+   * @brief Get the value type of this Settings object.
+   * @return `Type` enum value.
+   */
+  virtual Type getType() const = 0;
+
+  /**
+   * @brief Get the number of settings in this object.
+   * @return `size_t` Count.
+   */
+  virtual size_t getSize() const = 0;
+
+  /**
+   * @brief Get a NVS key string by index.
+   * @param index Index in the list.
+   * @retval `const char*` Key string.
+   * @retval `nullptr` Index out of bounds.
+   */
+  virtual const char* getKey(size_t index) const = 0;
+
+  /**
+   * @brief Get a hint string by index.
+   * @param index Index in the list.
+   * @retval `const char*` Hint string.
+   * @retval `nullptr` Index out of bounds.
+   */
+  virtual const char* getHint(size_t index) const = 0;
+
+  /**
+   * @brief Get a pointer to the default value. Cast to the correct type before use.
+   * @param index Index in the list.
+   * @retval `const void*` Pointer to default value.
+   * @retval `nullptr` Index out of bounds.
+   */
+  virtual const void* getDefaultValuePtr(size_t index) const = 0;
+
+  /**
+   * @brief Get the default value cast to type `T`.
+   * @tparam T Type to cast to.
+   * @param index Index in the list.
+   * @return `T` Default value, or a default-constructed `T` if out of bounds.
+   */
+  template <typename T>
+  T getDefaultValueAs(size_t index) const {
+    if (index >= getSize()) return T();
+    return *(static_cast<const T*>(getDefaultValuePtr(index)));
+  }
+
+  /**
+   * @brief Write a new value via untyped pointer.
+   * @param index Index in the list.
+   * @param value Pointer to the new value.
+   * @retval `true` Written successfully.
+   * @retval `false` Handle not open, index out of bounds, or NVS write error.
+   */
+  virtual bool setValuePtr(size_t index, const void* value) = 0;
+
+  /**
+   * @brief Read the current NVS value into a caller-provided buffer via untyped pointer.
+   * @param index Index in the list.
+   * @param value Destination buffer.
+   * @param size Size of the destination buffer in bytes.
+   * @retval `true` Read successfully.
+   * @retval `false` Handle not open, index out of bounds, or buffer too small.
+   */
+  virtual bool getValuePtr(size_t index, void* value, size_t size) = 0;
+
+  /**
+   * @brief Register a callback that fires on every value change across this object.
+   * @param callback Callback function.
+   * @param callable_on_format Whether to invoke the callback when a format operation writes a
+   * value.
+   */
+  virtual void setGlobalOnChangeCallback(GlobalOnChangeCb callback, bool callable_on_format) = 0;
+
+  /**
+   * @brief Remove the global change callback.
+   */
+  virtual void clearGlobalOnChangeCallback() = 0;
+
+  /**
+   * @brief Check whether the given key string exists in this object's list.
+   * @param key Key string to search.
+   * @param index_found Set to the matching index if found.
+   * @retval `true` Found.
+   * @retval `false` Not found.
+   */
+  virtual bool hasKey(const char* key, size_t& index_found) const = 0;
+
+  /**
+   * @brief Check whether a setting is marked as formattable.
+   * @param index Index in the list.
+   * @retval `true` Formattable.
+   * @retval `false` Not formattable or out of bounds.
+   */
+  virtual bool isFormattable(size_t index) const = 0;
+
+  /**
+   * @brief Write the default value back to NVS for a single setting.
+   * @param index Index in the list.
+   * @param force Ignore the formattable flag and write regardless.
+   * @retval `true` Written successfully.
+   * @retval `false` Not formattable (without force), out of bounds, or NVS error.
+   */
+  virtual bool format(size_t index, bool force = false) = 0;
+
+  /**
+   * @brief Write the default value back to NVS for all settings.
+   * @param force Ignore the formattable flag for all entries.
+   * @return `size_t` Number of entries that failed to write.
+   */
+  virtual size_t formatAll(bool force = false) = 0;
+};
+
+} // namespace NVS

--- a/src/internal/Policy.h
+++ b/src/internal/Policy.h
@@ -1,0 +1,209 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <nvs.h>
+#include <string.h>
+
+#include "Setting.h"
+#include "Types.h"
+
+namespace NVS {
+
+namespace Internal {
+
+/// @brief Policy for bool values. Stored as uint8_t (0 or 1).
+class BoolPolicy {
+  public:
+  bool setValue(nvs_handle_t handle, const char* key, bool value) {
+    if (nvs_set_u8(handle, key, value ? 1u : 0u) != ESP_OK) return false;
+    return nvs_commit(handle) == ESP_OK;
+  }
+
+  bool getValue(nvs_handle_t handle, const char* key, bool& value) {
+    uint8_t val;
+    if (nvs_get_u8(handle, key, &val) != ESP_OK) return false;
+    value = (val != 0);
+    return true;
+  }
+};
+
+/// @brief Policy for uint32_t values.
+class UInt32Policy {
+  public:
+  bool setValue(nvs_handle_t handle, const char* key, uint32_t value) {
+    if (nvs_set_u32(handle, key, value) != ESP_OK) return false;
+    return nvs_commit(handle) == ESP_OK;
+  }
+
+  bool getValue(nvs_handle_t handle, const char* key, uint32_t& value) {
+    if (nvs_get_u32(handle, key, &value) != ESP_OK) return false;
+    return true;
+  }
+};
+
+/// @brief Policy for int32_t values.
+class Int32Policy {
+  public:
+  bool setValue(nvs_handle_t handle, const char* key, int32_t value) {
+    if (nvs_set_i32(handle, key, value) != ESP_OK) return false;
+    return nvs_commit(handle) == ESP_OK;
+  }
+
+  bool getValue(nvs_handle_t handle, const char* key, int32_t& value) {
+    if (nvs_get_i32(handle, key, &value) != ESP_OK) return false;
+    return true;
+  }
+};
+
+/// @brief Policy for float values. Stored as uint32_t via memcpy to preserve bit representation.
+class FloatPolicy {
+  public:
+  bool setValue(nvs_handle_t handle, const char* key, float value) {
+    uint32_t bits;
+    memcpy(&bits, &value, sizeof(bits));
+    if (nvs_set_u32(handle, key, bits) != ESP_OK) return false;
+    return nvs_commit(handle) == ESP_OK;
+  }
+
+  bool getValue(nvs_handle_t handle, const char* key, float& value) {
+    uint32_t bits;
+    if (nvs_get_u32(handle, key, &bits) != ESP_OK) return false;
+    memcpy(&value, &bits, sizeof(value));
+    return true;
+  }
+};
+
+/**
+ * @brief Policy for double values. Stored as uint64_t via memcpy to preserve bit representation.
+ */
+class DoublePolicy {
+  public:
+  bool setValue(nvs_handle_t handle, const char* key, double value) {
+    uint64_t bits;
+    memcpy(&bits, &value, sizeof(bits));
+    if (nvs_set_u64(handle, key, bits) != ESP_OK) return false;
+    return nvs_commit(handle) == ESP_OK;
+  }
+
+  bool getValue(nvs_handle_t handle, const char* key, double& value) {
+    uint64_t bits;
+    if (nvs_get_u64(handle, key, &bits) != ESP_OK) return false;
+    memcpy(&value, &bits, sizeof(value));
+    return true;
+  }
+};
+
+/// @brief Policy for string values. Reads directly into a caller-provided buffer.
+class StringPolicy {
+  public:
+  bool setValue(nvs_handle_t handle, const char* key, StrView value) {
+    if (nvs_set_str(handle, key, value.data) != ESP_OK) return false;
+    return nvs_commit(handle) == ESP_OK;
+  }
+
+  bool getValue(nvs_handle_t handle, const char* key, Str& value) {
+    if (!value.data || value.max_size == 0) return false;
+
+    // Try to read and fit the value in the provided buffer
+    size_t required_size = 0;
+    if (nvs_get_str(handle, key, nullptr, &required_size) != ESP_OK) return false;
+    if (required_size > value.max_size) return false;
+    if (nvs_get_str(handle, key, value.data, &required_size) != ESP_OK) return false;
+
+    return true;
+  }
+};
+
+/// @brief Policy for binary blob values. Reads directly into a caller-provided buffer.
+class ByteStreamPolicy {
+  public:
+  bool setValue(nvs_handle_t handle, const char* key, ByteStreamView value) {
+    if (nvs_set_blob(handle, key, value.data, value.size) != ESP_OK) return false;
+    return nvs_commit(handle) == ESP_OK;
+  }
+
+  bool getValue(nvs_handle_t handle, const char* key, ByteStream& value) {
+    if (!value.data || value.max_size == 0) return false;
+
+    // Try to read and fit the value in the provided buffer
+    size_t required_size = 0;
+    if (nvs_get_blob(handle, key, nullptr, &required_size) != ESP_OK) return false;
+    if (required_size > value.max_size) return false;
+    if (nvs_get_blob(handle, key, value.data, &required_size) != ESP_OK) return false;
+
+    value.size = required_size;
+    return true;
+  }
+};
+
+/**
+ * @brief Maps C++ types to their corresponding policy, NVS::Type enum, and Setting struct.
+ * @tparam T Value type.
+ */
+template <typename T>
+struct PolicyTrait {};
+
+template <>
+struct PolicyTrait<bool> {
+  static const Type enum_type = Type::Bool;
+  using policy_type           = BoolPolicy;
+  using struct_type           = Setting<bool>;
+  using write_type            = bool;
+};
+
+template <>
+struct PolicyTrait<uint32_t> {
+  static const Type enum_type = Type::UInt32;
+  using policy_type           = UInt32Policy;
+  using struct_type           = Setting<uint32_t>;
+  using write_type            = uint32_t;
+};
+
+template <>
+struct PolicyTrait<int32_t> {
+  static const Type enum_type = Type::Int32;
+  using policy_type           = Int32Policy;
+  using struct_type           = Setting<int32_t>;
+  using write_type            = int32_t;
+};
+
+template <>
+struct PolicyTrait<float> {
+  static const Type enum_type = Type::Float;
+  using policy_type           = FloatPolicy;
+  using struct_type           = Setting<float>;
+  using write_type            = float;
+};
+
+template <>
+struct PolicyTrait<double> {
+  static const Type enum_type = Type::Double;
+  using policy_type           = DoublePolicy;
+  using struct_type           = Setting<double>;
+  using write_type            = double;
+};
+
+template <>
+struct PolicyTrait<Str> {
+  static const Type enum_type = Type::String;
+  using policy_type           = StringPolicy;
+  using struct_type           = Setting<Str>;
+  using write_type            = StrView;
+};
+
+template <>
+struct PolicyTrait<ByteStream> {
+  static const Type enum_type = Type::ByteStream;
+  using policy_type           = ByteStreamPolicy;
+  using struct_type           = Setting<ByteStream>;
+  using write_type            = ByteStreamView;
+};
+
+} // namespace Internal
+
+} // namespace NVS

--- a/src/internal/Setting.h
+++ b/src/internal/Setting.h
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "Types.h"
+
+namespace NVS {
+
+namespace Internal {
+
+/**
+ * @brief Metadata and default value for a single NVS setting entry.
+ * @note NVS key length is limited to 15 characters.
+ * @tparam T Type of the setting value.
+ */
+template <typename T>
+struct Setting {
+  const char* key;
+  const char* hint;
+  T default_value;
+  bool formattable;
+};
+
+/// @brief Specialization for Str: stores the default as a read-only StrView.
+template <>
+struct Setting<Str> {
+  const char* key;
+  const char* hint;
+  StrView default_value;
+  bool formattable;
+};
+
+/// @brief Specialization for ByteStream: stores the default as a read-only ByteStreamView.
+template <>
+struct Setting<ByteStream> {
+  const char* key;
+  const char* hint;
+  ByteStreamView default_value;
+  bool formattable;
+};
+
+} // namespace Internal
+
+} // namespace NVS

--- a/src/internal/Settings.h
+++ b/src/internal/Settings.h
@@ -182,6 +182,26 @@ class Settings : public ISettings {
   }
 
   /**
+   * @brief Read the current NVS value into a caller-provided buffer via untyped pointer, with
+   * fallback to the default value if the key is not found in NVS.
+   * @param index Index in the list.
+   * @param value Destination buffer.
+   * @param size Size of the destination buffer in bytes.
+   * @return `const void*` Pointer to the value read from NVS, or pointer to the default value if
+   * not found in NVS or on error.
+   */
+  const void* getValuePtrOrDefault(size_t index, void* value, size_t size) override {
+    if (index >= N) return nullptr;
+    if (size < sizeof(T)) return nullptr;
+
+    T& out = *static_cast<T*>(value);
+    if (!_policy.getValue(_handle, _list[index].key, out)) {
+      _applyDefault(out, _list[index].default_value);
+    }
+    return &out;
+  }
+
+  /**
    * @brief Register a callback that fires on every value change across this object.
    * @param callback Callback function.
    * @param callable_on_format Whether to invoke the callback when a format operation writes a
@@ -316,6 +336,25 @@ class Settings : public ISettings {
   }
 
   /**
+   * @brief Read the current value from NVS into `out`, with fallback to the default value if the
+   * key is not found in NVS.
+   *
+   * For NVS::Str: set `out.data` to a caller-owned buffer and `out.size` to its capacity
+   * before calling.
+   *
+   * For NVS::ByteStream: set `out.data` to a caller-owned buffer and `out.size` to its capacity
+   * before calling.
+   *
+   * @return The value read from NVS, or the default value if not found in NVS or on error.
+   */
+  T getValueOrDefault(ENUM setting, T& out) {
+    if (!_policy.getValue(_handle, getKey(static_cast<size_t>(setting)), out)) {
+      _applyDefault(out, _list[static_cast<size_t>(setting)].default_value);
+    }
+    return out;
+  }
+
+  /**
    * @brief Format a single setting to its default value.
    * @param force Ignore the formattable flag and write regardless.
    * @retval `true` Written successfully.
@@ -366,6 +405,22 @@ class Settings : public ISettings {
   Policy _policy;
 
   /* -------------------------------------- Private helpers ------------------------------------- */
+
+  static void _applyDefault(T& out, const WriteType& default_val) {
+    if constexpr (std::is_same_v<T, Str>) {
+      if (out.data && out.max_size > 0 && default_val.data) {
+        strncpy(out.data, default_val.data, out.max_size - 1);
+        out.data[out.max_size - 1] = '\0';
+      }
+    } else if constexpr (std::is_same_v<T, ByteStream>) {
+      if (out.data && default_val.data && out.max_size >= default_val.size) {
+        memcpy(out.data, default_val.data, default_val.size);
+        out.size = default_val.size;
+      }
+    } else {
+      out = default_val;
+    }
+  }
 
   bool setValueImpl(ENUM setting, const WriteType value, bool called_from_format) {
     if (!_is_open) return false;

--- a/src/internal/Settings.h
+++ b/src/internal/Settings.h
@@ -1,0 +1,392 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <initializer_list>
+#include <nvs.h>
+#include <string.h>
+#include <type_traits>
+
+#include "ISettings.h"
+#include "Policy.h"
+
+namespace NVS {
+
+/**
+ * @brief Typed settings container for a fixed list of NVS entries under a single namespace.
+ *
+ * Each instance owns its own NVS namespace handle, opened via `begin()` and closed via `end()`.
+ * Multiple instances may share the same namespace (keys must then be unique within it) or use
+ * independent namespaces, enabling reusable components with the same key set.
+ *
+ * @note NVS namespace names are limited to 15 characters.
+ *
+ * @tparam T Value type (`bool`, `uint32_t`, `int32_t`, `float`, `double`, `const char*`,
+ * `ByteStream`).
+ * @tparam ENUM Enum class whose enumerators index into the settings list.
+ * @tparam N Number of settings (use `SETTINGS_COUNT` macro).
+ */
+template <typename T, typename ENUM, size_t N>
+class Settings : public ISettings {
+  public:
+  using Policy    = typename Internal::PolicyTrait<T>::policy_type;
+  using Struct    = typename Internal::PolicyTrait<T>::struct_type;
+  using WriteType = typename Internal::PolicyTrait<T>::write_type;
+  using OnChangeCb =
+    std::function<void(const char* key, const ENUM setting, const WriteType updated_value)>;
+
+  /**
+   * @brief Construct a Settings object. Call `begin()` before any read/write operation.
+   * @param ns_name NVS namespace name (max 15 characters).
+   * @param list Initializer list of Setting structs, one per enum entry.
+   */
+  Settings(const char* ns_name, std::initializer_list<Struct> list)
+      : _ns_name(ns_name)
+      , _handle(0)
+      , _is_open(false)
+      , _global_on_change_cb(nullptr)
+      , _global_on_change_cb_callable_on_format(false) {
+    _on_change_cbs.fill(nullptr);
+    _on_change_cbs_callable_on_format.fill(false);
+    std::copy_n(list.begin(), N, _list.begin());
+  }
+
+  ~Settings() { end(); }
+
+  /* ----------------------------------------- Lifecycle ---------------------------------------- */
+
+  /**
+   * @brief Open the NVS namespace handle. Must be called after `NVS::init()`.
+   * @retval `true` Handle opened successfully.
+   * @retval `false` Operation failed.
+   */
+  bool begin() override {
+    if (_is_open) return true;
+    _is_open = (nvs_open(_ns_name, NVS_READWRITE, &_handle) == ESP_OK);
+    return _is_open;
+  }
+
+  /**
+   * @brief Close the NVS namespace handle.
+   */
+  void end() override {
+    if (!_is_open) return;
+    nvs_close(_handle);
+    _handle  = 0;
+    _is_open = false;
+  }
+
+  /**
+   * @brief Get the NVS namespace string used by this Settings object.
+   * @return Namespace string.
+   */
+  virtual const char* getNamespace() const override { return _ns_name; }
+
+  /**
+   * @brief Check whether the NVS handle is currently open.
+   * @retval `true` Handle is open.
+   * @retval `false` Handle is closed.
+   */
+  bool isOpen() const override { return _is_open; }
+
+  /**
+   * @brief Erase all keys in the namespace.
+   * @retval `true` All keys erased successfully.
+   * @retval `false` Operation failed.
+   */
+  bool eraseAll() override {
+    if (!_is_open) return false;
+    if (nvs_erase_all(_handle) != ESP_OK) return false;
+    return nvs_commit(_handle) == ESP_OK;
+  }
+
+  /* ------------------------------------ ISettings interface ----------------------------------- */
+
+  /**
+   * @brief Get the value type of this Settings object.
+   * @return `Type` enum value.
+   */
+  Type getType() const override { return Internal::PolicyTrait<T>::enum_type; }
+
+  /**
+   * @brief Get the number of settings in this object.
+   * @return `size_t` Count.
+   */
+  size_t getSize() const override { return N; }
+
+  /**
+   * @brief Get a NVS key string by index.
+   * @param index Index in the list.
+   * @retval `const char*` Key string.
+   * @retval `nullptr` Index out of bounds.
+   */
+  const char* getKey(size_t index) const override {
+    if (index >= N) return nullptr;
+    return _list[index].key;
+  }
+
+  /**
+   * @brief Get a hint string by index.
+   * @param index Index in the list.
+   * @retval `const char*` Hint string.
+   * @retval `nullptr` Index out of bounds.
+   */
+  const char* getHint(size_t index) const override {
+    if (index >= N) return nullptr;
+    return _list[index].hint;
+  }
+
+  /**
+   * @brief Get a pointer to the default value. Cast to the correct type before use.
+   * @param index Index in the list.
+   * @retval `const void*` Pointer to default value.
+   * @retval `nullptr` Index out of bounds.
+   */
+  const void* getDefaultValuePtr(size_t index) const override {
+    if (index >= N) return nullptr;
+    return &(_list[index].default_value);
+  }
+
+  /**
+   * @brief Write a new value via untyped pointer.
+   * @param index Index in the list.
+   * @param value Pointer to the new value.
+   * @retval `true` Written successfully.
+   * @retval `false` Handle not open, index out of bounds, or NVS write error.
+   */
+  bool setValuePtr(size_t index, const void* value) override {
+    if (index >= N) return false;
+    return setValueImpl(static_cast<ENUM>(index), *static_cast<const WriteType*>(value), false);
+  }
+
+  /**
+   * @brief Read the current NVS value into a caller-provided buffer via untyped pointer.
+   * @param index Index in the list.
+   * @param value Destination buffer.
+   * @param size Size of the destination buffer in bytes.
+   * @retval `true` Read successfully.
+   * @retval `false` Handle not open, index out of bounds, or buffer too small.
+   */
+  bool getValuePtr(size_t index, void* value, size_t size) override {
+    if (index >= N) return false;
+    if (size < sizeof(T)) return false;
+    T& out = *static_cast<T*>(value);
+    return _policy.getValue(_handle, _list[index].key, out);
+  }
+
+  /**
+   * @brief Register a callback that fires on every value change across this object.
+   * @param callback Callback function.
+   * @param callable_on_format Whether to invoke the callback when a format operation writes a
+   * value.
+   */
+  void setGlobalOnChangeCallback(GlobalOnChangeCb callback, bool callable_on_format) override {
+    _global_on_change_cb                    = callback;
+    _global_on_change_cb_callable_on_format = callable_on_format;
+  }
+
+  /**
+   * @brief Remove the global change callback.
+   */
+  void clearGlobalOnChangeCallback() override {
+    _global_on_change_cb                    = nullptr;
+    _global_on_change_cb_callable_on_format = false;
+  }
+
+  /**
+   * @brief Check whether the given key string exists in this object's list.
+   * @param key Key string to search.
+   * @param index_found Set to the matching index if found.
+   * @retval `true` Found.
+   * @retval `false` Not found.
+   */
+  bool hasKey(const char* key, size_t& index_found) const override {
+    for (size_t i = 0; i < N; i++) {
+      if (strcmp(_list[i].key, key) == 0) {
+        index_found = i;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @brief Check whether a setting is marked as formattable.
+   * @param index Index in the list.
+   * @retval `true` Formattable.
+   * @retval `false` Not formattable or out of bounds.
+   */
+  bool isFormattable(size_t index) const override {
+    if (index >= N) return false;
+    return _list[index].formattable;
+  }
+
+  /**
+   * @brief Write the default value back to NVS for a single setting.
+   * @param index Index in the list.
+   * @param force Ignore the formattable flag and write regardless.
+   * @retval `true` Written successfully.
+   * @retval `false` Not formattable (without force), out of bounds, or NVS error.
+   */
+  bool format(size_t index, bool force = false) override {
+    if (index >= N) return false;
+    if (!isFormattable(index) && !force) return false;
+    return setValueImpl(static_cast<ENUM>(index), getDefaultValue(index), true);
+  }
+
+  /**
+   * @brief Write the default value back to NVS for all settings.
+   * @param force Ignore the formattable flag for all entries.
+   * @return `size_t` Number of entries that failed to write.
+   */
+  size_t formatAll(bool force = false) override {
+    size_t errors = 0;
+    for (size_t i = 0; i < N; i++) {
+      if (!isFormattable(i) && !force) continue;
+      if (!setValueImpl(static_cast<ENUM>(i), getDefaultValue(i), true)) errors++;
+    }
+    return errors;
+  }
+
+  /* ----------------------------------------- Typed API ---------------------------------------- */
+
+  /**
+   * @brief Get a NVS key string by enum entry.
+   * @param setting Enum entry.
+   * @return `const char*` Key string.
+   */
+  const char* getKey(ENUM setting) const { return _list[static_cast<size_t>(setting)].key; }
+
+  /**
+   * @brief Get a hint string by enum entry.
+   * @param setting Enum entry.
+   * @return `const char*` Hint string.
+   */
+  const char* getHint(ENUM setting) const { return _list[static_cast<size_t>(setting)].hint; }
+
+  /**
+   * @brief Get the default value by index.
+   * @param index Index in the list.
+   * @return `WriteType` Default value.
+   */
+  WriteType getDefaultValue(size_t index) const {
+    if (index >= N) return WriteType();
+    return _list[index].default_value;
+  }
+
+  /**
+   * @brief Get the default value by enum entry.
+   * @param setting Enum entry.
+   * @return `WriteType` Default value.
+   */
+  WriteType getDefaultValue(ENUM setting) const {
+    return _list[static_cast<size_t>(setting)].default_value;
+  }
+
+  /**
+   * @brief Write a new value to NVS.
+   * @param setting Enum entry.
+   * @param value Value to write.
+   * @retval `true` Written successfully.
+   * @retval `false` Handle not open or NVS write error.
+   */
+  bool setValue(ENUM setting, const WriteType value) { return setValueImpl(setting, value, false); }
+
+  /**
+   * @brief Read the current value from NVS into `out`.
+   *
+   * For NVS::Str: set `out.data` to a caller-owned buffer and `out.size` to its capacity
+   * before calling.
+   *
+   * For NVS::ByteStream: set `out.data` to a caller-owned buffer and `out.size` to its capacity
+   * before calling.
+   *
+   * @retval `true` Value was read from NVS.
+   * @retval `false` Value not found in NVS, handle not open, or buffer too small.
+   */
+  bool getValue(ENUM setting, T& out) {
+    return _policy.getValue(_handle, getKey(static_cast<size_t>(setting)), out);
+  }
+
+  /**
+   * @brief Format a single setting to its default value.
+   * @param force Ignore the formattable flag and write regardless.
+   * @retval `true` Written successfully.
+   * @retval `false` Not formattable (without force), out of bounds, or NVS error.
+   */
+  bool format(ENUM setting, bool force = false) {
+    return format(static_cast<size_t>(setting), force);
+  }
+
+  /**
+   * @brief Check whether a setting is marked as formattable.
+   * @retval `true` Setting is formattable.
+   * @retval `false` Setting is not formattable.
+   */
+  bool isFormattable(ENUM setting) const { return _list[static_cast<size_t>(setting)].formattable; }
+
+  /**
+   * @brief Register a callback for a specific setting.
+   * @param callable_on_format Whether to invoke when a format operation writes this setting.
+   */
+  void setOnChangeCallback(ENUM setting, OnChangeCb callback, bool callable_on_format) {
+    size_t index                             = static_cast<size_t>(setting);
+    _on_change_cbs[index]                    = callback;
+    _on_change_cbs_callable_on_format[index] = callable_on_format;
+  }
+
+  /**
+   * @brief Remove the callback for a specific setting.
+   */
+  void clearOnChangeCallback(ENUM setting) {
+    size_t index                             = static_cast<size_t>(setting);
+    _on_change_cbs[index]                    = nullptr;
+    _on_change_cbs_callable_on_format[index] = false;
+  }
+
+  private:
+  const char* _ns_name;
+  nvs_handle_t _handle;
+  bool _is_open;
+
+  GlobalOnChangeCb _global_on_change_cb;
+  bool _global_on_change_cb_callable_on_format;
+
+  std::array<OnChangeCb, N> _on_change_cbs;
+  std::array<bool, N> _on_change_cbs_callable_on_format;
+
+  std::array<Struct, N> _list;
+  Policy _policy;
+
+  /* -------------------------------------- Private helpers ------------------------------------- */
+
+  bool setValueImpl(ENUM setting, const WriteType value, bool called_from_format) {
+    if (!_is_open) return false;
+
+    size_t index = static_cast<size_t>(setting);
+
+    if (!_policy.setValue(_handle, getKey(index), value)) return false;
+
+    bool call_global = called_from_format ? _global_on_change_cb_callable_on_format : true;
+    bool call_local  = called_from_format ? _on_change_cbs_callable_on_format[index] : true;
+
+    if (call_global && _global_on_change_cb) {
+      _global_on_change_cb(getKey(setting), getType(), index, &value);
+    }
+
+    if (call_local && _on_change_cbs[index]) {
+      _on_change_cbs[index](getKey(setting), setting, value);
+    }
+
+    return true;
+  }
+};
+
+} // namespace NVS

--- a/src/internal/Settings.h
+++ b/src/internal/Settings.h
@@ -187,18 +187,18 @@ class Settings : public ISettings {
    * @param index Index in the list.
    * @param value Destination buffer.
    * @param size Size of the destination buffer in bytes.
-   * @return `const void*` Pointer to the value read from NVS, or pointer to the default value if
-   * not found in NVS or on error.
+   * @retval `true` Value read from NVS or default value.
+   * @retval `false` Handle not open, index out of bounds, or buffer too small.
    */
-  const void* getValuePtrOrDefault(size_t index, void* value, size_t size) override {
-    if (index >= N) return nullptr;
-    if (size < sizeof(T)) return nullptr;
+  bool getValuePtrOrDefault(size_t index, void* value, size_t size) override {
+    if (index >= N) return false;
+    if (size < sizeof(T)) return false;
 
     T& out = *static_cast<T*>(value);
     if (!_policy.getValue(_handle, _list[index].key, out)) {
       _applyDefault(out, _list[index].default_value);
     }
-    return &out;
+    return true;
   }
 
   /**

--- a/src/internal/Types.h
+++ b/src/internal/Types.h
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace NVS {
+
+/// @brief Type of a Settings object. Useful when using ISettings pointers.
+enum class Type : uint8_t { Bool, UInt32, Int32, Float, Double, String, ByteStream };
+
+/// @brief Read-only view of a string. Used for default values and write operations.
+struct StrView {
+  // Pointer to a null-terminated string. Must be valid for the lifetime of the Settings object.
+  const char* data;
+
+  // Size of the string in bytes, including the null terminator. Set by the library when reading, or
+  // by the user when creating a StrView for default values.
+  size_t size;
+
+  StrView(const char* d = nullptr)
+      : data(d)
+      , size(d ? (strlen(d) + 1) : 0) {}
+};
+
+/// @brief Mutable string buffer for read operations. Caller must allocate the buffer.
+struct Str {
+  char* data;      // Pointer to char buffer. Must be of max_size bytes allocated by the user.
+  size_t max_size; // Max capacity of the buffer in bytes, including space for null terminator.
+
+  Str(char* d = nullptr, const size_t s = 0)
+      : data(d)
+      , max_size(s) {}
+
+  // Implicit conversion to StrView for convenience in default values and setValue calls.
+  operator StrView() const { return StrView{data}; }
+};
+
+struct ByteStreamView;
+
+/// @brief Mutable byte buffer for read operations. Caller must allocate the buffer.
+struct ByteStream {
+  // Optional data format metadata. Not persisted in NVS.
+  enum class Format : uint8_t { Hex, Base64, JSONObject, JSONArray } format;
+
+  uint8_t* data;   // Pointer to byte buffer. Must be of max_size bytes allocated by the user.
+  size_t size;     // Size of the valid data in bytes. Set by the library when reading.
+  size_t max_size; // Max capacity of the buffer in bytes. Set by the user.
+
+  ByteStream(uint8_t* d = nullptr, size_t max_s = 0, Format f = Format::Hex)
+      : format(f)
+      , data(d)
+      , size(0)
+      , max_size(max_s) {}
+
+  // Implicit conversion to ByteStreamView for convenience in default values and setValue calls.
+  operator ByteStreamView() const;
+};
+
+/// @brief Read-only view of a byte blob. Used for default values and write operations.
+struct ByteStreamView {
+  // Pointer to byte data. Must be valid for the lifetime of the Settings object.
+  const uint8_t* data;
+
+  // Size of the byte blob in bytes. Set by the user for default values, or by the library when
+  // reading.
+  size_t size;
+
+  // Optional data format metadata. Not persisted in NVS.
+  ByteStream::Format format;
+
+  ByteStreamView(const uint8_t* d = nullptr, size_t s = 0,
+                 ByteStream::Format f = ByteStream::Format::Hex)
+      : data(d)
+      , size(s)
+      , format(f) {}
+};
+
+inline ByteStream::operator ByteStreamView() const { return ByteStreamView{data, size, format}; }
+
+} // namespace NVS

--- a/test/test_settings.cpp
+++ b/test/test_settings.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
+ * SPDX-FileCopyrightText: 2026 Maximiliano Ramirez <maximiliano.ramirezbravo@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -9,7 +9,7 @@
 #define UNITY_INCLUDE_DOUBLE
 #include <unity.h>
 
-#include "SettingsManagerESP32.h"
+#include <SettingsManagerESP32.h>
 
 /* ---------------------------------------------------------------------------------------------- */
 // - 3 settings for each type. The test will write to NVS only 2 of them, the third will be
@@ -48,11 +48,11 @@
   X(String_2, "My String 2", "str 2", false) \
   X(String_3, "My String 3", "str 3", false)
 
-const NVS::ByteStream bytestream1_default = {
+const NVS::ByteStreamView bytestream1_default = {
   reinterpret_cast<const uint8_t*>("nvs1"), 5, NVS::ByteStream::Format::Hex};
-const NVS::ByteStream bytestream2_default = {
+const NVS::ByteStreamView bytestream2_default = {
   reinterpret_cast<const uint8_t*>("nvs2"), 5, NVS::ByteStream::Format::Base64};
-const NVS::ByteStream bytestream3_default = {
+const NVS::ByteStreamView bytestream3_default = {
   reinterpret_cast<const uint8_t*>("nvs3"), 5, NVS::ByteStream::Format::JSONObject};
 #define BYTESTREAMS(X)                                       \
   X(Stream_1, "My ByteStream 1", bytestream1_default, false) \
@@ -71,39 +71,38 @@ double new_double[NVS_VALUES]      = {11.123456789, 22.123456789};
 const char* new_string[NVS_VALUES] = {"hello 1", "hello 2"};
 
 // Bytestream new values
-// - Here the format is changed, but it is not changed in NVS when calling setValue()
-// - The default ByteStream's format is the one that matters. So, when calling getValue(), the
-// format member will be the one defined in the default value.
-NVS::ByteStream new_bytestream[NVS_VALUES] = {
+NVS::ByteStreamView new_bytestream[NVS_VALUES] = {
   {reinterpret_cast<const uint8_t*>("test1"), 5, NVS::ByteStream::Format::JSONArray},
   {reinterpret_cast<const uint8_t*>("test2"), 5, NVS::ByteStream::Format::Base64   }
 };
 
 // Instantiation of settings
 enum class Bools : uint8_t { BOOLS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<bool, Bools, SETTINGS_COUNT(BOOLS)> bools = {BOOLS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<bool, Bools, SETTINGS_COUNT(BOOLS)> bools("test", {BOOLS(SETTINGS_EXPAND_SETTINGS)});
 
 enum class UInt32s : uint8_t { UINT32S(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<uint32_t, UInt32s, SETTINGS_COUNT(UINT32S)> uint32s = {
-  UINT32S(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<uint32_t, UInt32s, SETTINGS_COUNT(UINT32S)>
+  uint32s("test", {UINT32S(SETTINGS_EXPAND_SETTINGS)});
 
 enum class Int32s : uint8_t { INT32S(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<int32_t, Int32s, SETTINGS_COUNT(INT32S)> int32s = {INT32S(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<int32_t, Int32s, SETTINGS_COUNT(INT32S)> int32s("test",
+                                                              {INT32S(SETTINGS_EXPAND_SETTINGS)});
 
 enum class Floats : uint8_t { FLOATS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<float, Floats, SETTINGS_COUNT(FLOATS)> floats = {FLOATS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<float, Floats, SETTINGS_COUNT(FLOATS)> floats("test",
+                                                            {FLOATS(SETTINGS_EXPAND_SETTINGS)});
 
 enum class Doubles : uint8_t { DOUBLES(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<double, Doubles, SETTINGS_COUNT(DOUBLES)> doubles = {
-  DOUBLES(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<double, Doubles, SETTINGS_COUNT(DOUBLES)>
+  doubles("test", {DOUBLES(SETTINGS_EXPAND_SETTINGS)});
 
 enum class Strings : uint8_t { STRINGS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<const char*, Strings, SETTINGS_COUNT(STRINGS)> strings = {
-  STRINGS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<NVS::Str, Strings, SETTINGS_COUNT(STRINGS)>
+  strings("test", {STRINGS(SETTINGS_EXPAND_SETTINGS)});
 
 enum class ByteStreams : uint8_t { BYTESTREAMS(SETTINGS_EXPAND_ENUM_CLASS) };
-NVS::Settings<NVS::ByteStream, ByteStreams, SETTINGS_COUNT(BYTESTREAMS)> bytestreams = {
-  BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)};
+NVS::Settings<NVS::ByteStream, ByteStreams, SETTINGS_COUNT(BYTESTREAMS)>
+  bytestreams("test", {BYTESTREAMS(SETTINGS_EXPAND_SETTINGS)});
 
 NVS::ISettings* settings[] = {&bools, &uint32s, &int32s, &floats, &doubles, &strings, &bytestreams};
 constexpr size_t settings_size = sizeof(settings) / sizeof(settings[0]);
@@ -159,12 +158,13 @@ void doubleCallback(const char* key, const Doubles setting, const double value) 
 }
 
 uint8_t string_callback_entries = 0;
-void stringCallback(const char* key, const Strings setting, const char* const value) {
+void stringCallback(const char* key, const Strings setting, const NVS::StrView value) {
   string_callback_entries++;
 }
 
 uint8_t bytestream_callback_entries = 0;
-void bytestreamCallback(const char* key, const ByteStreams setting, const NVS::ByteStream value) {
+void bytestreamCallback(const char* key, const ByteStreams setting,
+                        const NVS::ByteStreamView value) {
   bytestream_callback_entries++;
 }
 
@@ -352,9 +352,18 @@ void setup() {
 void loop() {}
 
 /* ---------------------------------------------------------------------------------------------- */
-void test_initializeNVS() { TEST_ASSERT(nvs.begin("esp32")); }
+void test_initializeNVS() {
+  TEST_ASSERT(NVS::init());
+  for (size_t i = 0; i < settings_size; i++) {
+    TEST_ASSERT(settings[i]->begin());
+  }
+}
 
-void test_clearNVS() { TEST_ASSERT(nvs.clear()); }
+void test_clearNVS() {
+  // Erase all keys in the shared "test" namespace via the first open handle.
+  // All other objects share the same namespace, so their keys are erased too.
+  TEST_ASSERT(settings[0]->eraseAll());
+}
 
 void test_getType() {
   TEST_ASSERT(bools.getType() == NVS::Type::Bool);
@@ -400,8 +409,11 @@ void test_bools_setValue() {
 }
 
 void test_bools_getValue() {
-  TEST_ASSERT_EQUAL(new_bool[0], bools.getValue(Bools::Bool_1));
-  TEST_ASSERT_EQUAL(new_bool[1], bools.getValue(Bools::Bool_2));
+  bool val;
+  TEST_ASSERT(bools.getValue(Bools::Bool_1, val));
+  TEST_ASSERT_EQUAL(new_bool[0], val);
+  TEST_ASSERT(bools.getValue(Bools::Bool_2, val));
+  TEST_ASSERT_EQUAL(new_bool[1], val);
 }
 
 void test_bools_hasKey() {
@@ -430,7 +442,9 @@ void test_bools_pointer() {
     // Value
     bool value;
     TEST_ASSERT_TRUE(settings[ID_Bools]->getValuePtr(i, &value, sizeof(value)));
-    TEST_ASSERT_EQUAL(bools.getValue(static_cast<Bools>(i)), value);
+    bool bval;
+    bools.getValue(static_cast<Bools>(i), bval);
+    TEST_ASSERT_EQUAL(bval, value);
 
     // Default value
     TEST_ASSERT_EQUAL(bools.getDefaultValue(static_cast<Bools>(i)),
@@ -450,17 +464,18 @@ void test_bools_pointer() {
   // Buffer too small
   TEST_ASSERT_FALSE(settings[ID_Bools]->getValuePtr(0, &value, 0));
 
-  // NVS key not saved in the NVS yet, returns default value
+  // NVS key not saved yet - getValuePtr returns false and leaves value unmodified
   uint8_t idx_nullptr = idx_out - 1;
-  TEST_ASSERT_TRUE(settings[ID_Bools]->getValuePtr(idx_nullptr, &value, sizeof(value)));
-  TEST_ASSERT_EQUAL(bools.getDefaultValue(static_cast<Bools>(idx_nullptr)), value);
+  TEST_ASSERT_FALSE(settings[ID_Bools]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
 void test_bools_format() {
   TEST_ASSERT_EQUAL(0, bools.formatAll());
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL(new_bool[i], bools.getValue(static_cast<Bools>(i)));
+    bool val;
+    bools.getValue(static_cast<Bools>(i), val);
+    TEST_ASSERT_EQUAL(new_bool[i], val);
   }
 }
 
@@ -468,8 +483,9 @@ void test_bools_forceFormat() {
   TEST_ASSERT_EQUAL(0, bools.formatAll(true));
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL(bools.getDefaultValue(static_cast<Bools>(i)),
-                      bools.getValue(static_cast<Bools>(i)));
+    bool val;
+    bools.getValue(static_cast<Bools>(i), val);
+    TEST_ASSERT_EQUAL(bools.getDefaultValue(static_cast<Bools>(i)), val);
   }
 }
 /* ---------------------------------------------------------------------------------------------- */
@@ -496,8 +512,11 @@ void test_uint32s_setValue() {
 }
 
 void test_uint32s_getValue() {
-  TEST_ASSERT_EQUAL_UINT32(new_uint32[0], uint32s.getValue(UInt32s::UInt32_1));
-  TEST_ASSERT_EQUAL_UINT32(new_uint32[1], uint32s.getValue(UInt32s::UInt32_2));
+  uint32_t val;
+  TEST_ASSERT(uint32s.getValue(UInt32s::UInt32_1, val));
+  TEST_ASSERT_EQUAL_UINT32(new_uint32[0], val);
+  TEST_ASSERT(uint32s.getValue(UInt32s::UInt32_2, val));
+  TEST_ASSERT_EQUAL_UINT32(new_uint32[1], val);
 }
 
 void test_uint32s_hasKey() {
@@ -526,11 +545,13 @@ void test_uint32s_pointer() {
     // Value
     uint32_t value;
     TEST_ASSERT_TRUE(settings[ID_UInt32s]->getValuePtr(i, &value, sizeof(value)));
-    TEST_ASSERT_EQUAL_UINT32(uint32s.getValue(static_cast<UInt32s>(i)), value);
+    uint32_t uval;
+    uint32s.getValue(static_cast<UInt32s>(i), uval);
+    TEST_ASSERT_EQUAL_UINT32(uval, value);
 
     // Default value
     TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(static_cast<UInt32s>(i)),
-                             settings[ID_UInt32s]->getDefaultValueAs<bool>(i));
+                             settings[ID_UInt32s]->getDefaultValueAs<uint32_t>(i));
   }
 
   // Index out of bounds
@@ -546,17 +567,18 @@ void test_uint32s_pointer() {
   // Buffer too small
   TEST_ASSERT_FALSE(settings[ID_UInt32s]->getValuePtr(0, &value, 0));
 
-  // NVS key not saved in the NVS yet, returns default value
+  // NVS key not saved yet - getValuePtr returns false and leaves value unmodified
   uint8_t idx_nullptr = idx_out - 1;
-  TEST_ASSERT_TRUE(settings[ID_UInt32s]->getValuePtr(idx_nullptr, &value, sizeof(value)));
-  TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(static_cast<UInt32s>(idx_nullptr)), value);
+  TEST_ASSERT_FALSE(settings[ID_UInt32s]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
 void test_uint32s_format() {
   TEST_ASSERT_EQUAL(0, uint32s.formatAll());
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_UINT32(new_uint32[i], uint32s.getValue(static_cast<UInt32s>(i)));
+    uint32_t val;
+    uint32s.getValue(static_cast<UInt32s>(i), val);
+    TEST_ASSERT_EQUAL_UINT32(new_uint32[i], val);
   }
 }
 
@@ -564,8 +586,9 @@ void test_uint32s_forceFormat() {
   TEST_ASSERT_EQUAL(0, uint32s.formatAll(true));
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(static_cast<UInt32s>(i)),
-                             uint32s.getValue(static_cast<UInt32s>(i)));
+    uint32_t val;
+    uint32s.getValue(static_cast<UInt32s>(i), val);
+    TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(static_cast<UInt32s>(i)), val);
   }
 }
 /* ---------------------------------------------------------------------------------------------- */
@@ -582,8 +605,8 @@ void test_int32s_getHint() {
 }
 
 void test_int32s_getDefaultValue() {
-  TEST_ASSERT_EQUAL_INT32(1, uint32s.getDefaultValue(UInt32s::UInt32_1));
-  TEST_ASSERT_EQUAL_INT32(2, uint32s.getDefaultValue(UInt32s::UInt32_2));
+  TEST_ASSERT_EQUAL_INT32(-1, int32s.getDefaultValue(Int32s::Int32_1));
+  TEST_ASSERT_EQUAL_INT32(-2, int32s.getDefaultValue(Int32s::Int32_2));
 }
 
 void test_int32s_setValue() {
@@ -592,8 +615,11 @@ void test_int32s_setValue() {
 }
 
 void test_int32s_getValue() {
-  TEST_ASSERT_EQUAL_INT32(new_int32[0], int32s.getValue(Int32s::Int32_1));
-  TEST_ASSERT_EQUAL_INT32(new_int32[1], int32s.getValue(Int32s::Int32_2));
+  int32_t val;
+  TEST_ASSERT(int32s.getValue(Int32s::Int32_1, val));
+  TEST_ASSERT_EQUAL_INT32(new_int32[0], val);
+  TEST_ASSERT(int32s.getValue(Int32s::Int32_2, val));
+  TEST_ASSERT_EQUAL_INT32(new_int32[1], val);
 }
 
 void test_int32s_hasKey() {
@@ -622,7 +648,9 @@ void test_int32s_pointer() {
     // Value
     int32_t value;
     TEST_ASSERT_TRUE(settings[ID_Int32s]->getValuePtr(i, &value, sizeof(value)));
-    TEST_ASSERT_EQUAL_INT32(int32s.getValue(static_cast<Int32s>(i)), value);
+    int32_t ival;
+    int32s.getValue(static_cast<Int32s>(i), ival);
+    TEST_ASSERT_EQUAL_INT32(ival, value);
 
     // Default value
     TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(static_cast<Int32s>(i)),
@@ -642,17 +670,18 @@ void test_int32s_pointer() {
   // Buffer too small
   TEST_ASSERT_FALSE(settings[ID_Int32s]->getValuePtr(0, &value, 0));
 
-  // NVS key not saved in the NVS yet, returns default value
+  // NVS key not saved yet - getValuePtr returns false and leaves value unmodified
   uint8_t idx_nullptr = idx_out - 1;
-  TEST_ASSERT_TRUE(settings[ID_Int32s]->getValuePtr(idx_nullptr, &value, sizeof(value)));
-  TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(static_cast<Int32s>(idx_nullptr)), value);
+  TEST_ASSERT_FALSE(settings[ID_Int32s]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
 void test_int32s_format() {
   TEST_ASSERT_EQUAL(0, int32s.formatAll());
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_INT32(new_int32[i], int32s.getValue(static_cast<Int32s>(i)));
+    int32_t val;
+    int32s.getValue(static_cast<Int32s>(i), val);
+    TEST_ASSERT_EQUAL_INT32(new_int32[i], val);
   }
 }
 
@@ -660,8 +689,9 @@ void test_int32s_forceFormat() {
   TEST_ASSERT_EQUAL(0, int32s.formatAll(true));
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(static_cast<Int32s>(i)),
-                            int32s.getValue(static_cast<Int32s>(i)));
+    int32_t val;
+    int32s.getValue(static_cast<Int32s>(i), val);
+    TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(static_cast<Int32s>(i)), val);
   }
 }
 /* ---------------------------------------------------------------------------------------------- */
@@ -688,8 +718,11 @@ void test_floats_setValue() {
 }
 
 void test_floats_getValue() {
-  TEST_ASSERT_EQUAL_FLOAT(new_float[0], floats.getValue(Floats::Float_1));
-  TEST_ASSERT_EQUAL_FLOAT(new_float[1], floats.getValue(Floats::Float_2));
+  float val;
+  TEST_ASSERT(floats.getValue(Floats::Float_1, val));
+  TEST_ASSERT_EQUAL_FLOAT(new_float[0], val);
+  TEST_ASSERT(floats.getValue(Floats::Float_2, val));
+  TEST_ASSERT_EQUAL_FLOAT(new_float[1], val);
 }
 
 void test_floats_hasKey() {
@@ -718,7 +751,9 @@ void test_floats_pointer() {
     // Value
     float value;
     TEST_ASSERT_TRUE(settings[ID_Floats]->getValuePtr(i, &value, sizeof(value)));
-    TEST_ASSERT_EQUAL_FLOAT(floats.getValue(static_cast<Floats>(i)), value);
+    float fval;
+    floats.getValue(static_cast<Floats>(i), fval);
+    TEST_ASSERT_EQUAL_FLOAT(fval, value);
 
     // Default value
     TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(static_cast<Floats>(i)),
@@ -738,17 +773,18 @@ void test_floats_pointer() {
   // Buffer too small
   TEST_ASSERT_FALSE(settings[ID_Floats]->getValuePtr(0, &value, 0));
 
-  // NVS key not saved in the NVS yet, returns default value
+  // NVS key not saved yet - getValuePtr returns false and leaves value unmodified
   uint8_t idx_nullptr = idx_out - 1;
-  TEST_ASSERT_TRUE(settings[ID_Floats]->getValuePtr(idx_nullptr, &value, sizeof(value)));
-  TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(static_cast<Floats>(idx_nullptr)), value);
+  TEST_ASSERT_FALSE(settings[ID_Floats]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
 void test_floats_format() {
   TEST_ASSERT_EQUAL(0, floats.formatAll());
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_FLOAT(new_float[i], floats.getValue(static_cast<Floats>(i)));
+    float val;
+    floats.getValue(static_cast<Floats>(i), val);
+    TEST_ASSERT_EQUAL_FLOAT(new_float[i], val);
   }
 }
 
@@ -756,8 +792,9 @@ void test_floats_forceFormat() {
   TEST_ASSERT_EQUAL(0, floats.formatAll(true));
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(static_cast<Floats>(i)),
-                            floats.getValue(static_cast<Floats>(i)));
+    float val;
+    floats.getValue(static_cast<Floats>(i), val);
+    TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(static_cast<Floats>(i)), val);
   }
 }
 /* ---------------------------------------------------------------------------------------------- */
@@ -784,8 +821,11 @@ void test_doubles_setValue() {
 }
 
 void test_doubles_getValue() {
-  TEST_ASSERT_EQUAL_DOUBLE(new_double[0], doubles.getValue(Doubles::Double_1));
-  TEST_ASSERT_EQUAL_DOUBLE(new_double[1], doubles.getValue(Doubles::Double_2));
+  double val;
+  TEST_ASSERT(doubles.getValue(Doubles::Double_1, val));
+  TEST_ASSERT_EQUAL_DOUBLE(new_double[0], val);
+  TEST_ASSERT(doubles.getValue(Doubles::Double_2, val));
+  TEST_ASSERT_EQUAL_DOUBLE(new_double[1], val);
 }
 
 void test_doubles_hasKey() {
@@ -814,7 +854,9 @@ void test_doubles_pointer() {
     // Value
     double value;
     TEST_ASSERT_TRUE(settings[ID_Doubles]->getValuePtr(i, &value, sizeof(value)));
-    TEST_ASSERT_EQUAL_DOUBLE(doubles.getValue(static_cast<Doubles>(i)), value);
+    double dval;
+    doubles.getValue(static_cast<Doubles>(i), dval);
+    TEST_ASSERT_EQUAL_DOUBLE(dval, value);
 
     // Default value
     TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(static_cast<Doubles>(i)),
@@ -834,17 +876,18 @@ void test_doubles_pointer() {
   // Buffer too small
   TEST_ASSERT_FALSE(settings[ID_Doubles]->getValuePtr(0, &value, 0));
 
-  // NVS key not saved in the NVS yet, returns default value
+  // NVS key not saved yet - getValuePtr returns false and leaves value unmodified
   uint8_t idx_nullptr = idx_out - 1;
-  TEST_ASSERT_TRUE(settings[ID_Doubles]->getValuePtr(idx_nullptr, &value, sizeof(value)));
-  TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(static_cast<Doubles>(idx_nullptr)), value);
+  TEST_ASSERT_FALSE(settings[ID_Doubles]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
 void test_doubles_format() {
   TEST_ASSERT_EQUAL(0, doubles.formatAll());
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_DOUBLE(new_double[i], doubles.getValue(static_cast<Doubles>(i)));
+    double val;
+    doubles.getValue(static_cast<Doubles>(i), val);
+    TEST_ASSERT_EQUAL_DOUBLE(new_double[i], val);
   }
 }
 
@@ -852,8 +895,9 @@ void test_doubles_forceFormat() {
   TEST_ASSERT_EQUAL(0, doubles.formatAll(true));
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(static_cast<Doubles>(i)),
-                             doubles.getValue(static_cast<Doubles>(i)));
+    double val;
+    doubles.getValue(static_cast<Doubles>(i), val);
+    TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(static_cast<Doubles>(i)), val);
   }
 }
 /* ---------------------------------------------------------------------------------------------- */
@@ -870,20 +914,23 @@ void test_strings_getHint() {
 }
 
 void test_strings_getDefaultValue() {
-  TEST_ASSERT_EQUAL_STRING("str 1", strings.getDefaultValue(Strings::String_1));
-  TEST_ASSERT_EQUAL_STRING("str 2", strings.getDefaultValue(Strings::String_2));
+  TEST_ASSERT_EQUAL_STRING("str 1", strings.getDefaultValue(Strings::String_1).data);
+  TEST_ASSERT_EQUAL_STRING("str 2", strings.getDefaultValue(Strings::String_2).data);
 }
 
 void test_strings_setValue() {
-  TEST_ASSERT(strings.setValue(Strings::String_1, new_string[0]));
-  TEST_ASSERT(strings.setValue(Strings::String_2, new_string[1]));
+  TEST_ASSERT(strings.setValue(Strings::String_1, NVS::StrView{new_string[0]}));
+  TEST_ASSERT(strings.setValue(Strings::String_2, NVS::StrView{new_string[1]}));
 }
 
 void test_strings_getValue() {
-  TEST_ASSERT_EQUAL_STRING(new_string[0], strings.getValue(Strings::String_1));
-  strings.giveMutex();
-  TEST_ASSERT_EQUAL_STRING(new_string[1], strings.getValue(Strings::String_2));
-  strings.giveMutex();
+  char buf[32];
+  NVS::Str out{buf, sizeof(buf)};
+  TEST_ASSERT(strings.getValue(Strings::String_1, out));
+  TEST_ASSERT_EQUAL_STRING(new_string[0], out.data);
+  out = {buf, sizeof(buf)};
+  TEST_ASSERT(strings.getValue(Strings::String_2, out));
+  TEST_ASSERT_EQUAL_STRING(new_string[1], out.data);
 }
 
 void test_strings_hasKey() {
@@ -909,16 +956,17 @@ void test_strings_pointer() {
     sprintf(buffer, "My String %u", i + 1);
     TEST_ASSERT_EQUAL_STRING(buffer, settings[ID_Strings]->getHint(i));
 
-    // Value
-    TEST_ASSERT_TRUE(settings[ID_Strings]->getValuePtr(i, buffer, sizeof(buffer)));
-    settings[ID_Strings]->giveMutex();
-
-    TEST_ASSERT_EQUAL_STRING(strings.getValue(static_cast<Strings>(i)), buffer);
-    settings[ID_Strings]->giveMutex();
+    // Value via pointer interface
+    NVS::Str ptr_out{buffer, sizeof(buffer)};
+    TEST_ASSERT_TRUE(settings[ID_Strings]->getValuePtr(i, &ptr_out, sizeof(ptr_out)));
+    char sval[64];
+    NVS::Str sval_ns{sval, sizeof(sval)};
+    strings.getValue(static_cast<Strings>(i), sval_ns);
+    TEST_ASSERT_EQUAL_STRING(sval, buffer);
 
     // Default value
-    TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(static_cast<Strings>(i)),
-                             settings[ID_Strings]->getDefaultValueAs<const char*>(i));
+    TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(static_cast<Strings>(i)).data,
+                             settings[ID_Strings]->getDefaultValueAs<NVS::StrView>(i).data);
   }
 
   // Index out of bounds
@@ -926,28 +974,29 @@ void test_strings_pointer() {
 
   TEST_ASSERT_NULL(settings[ID_Strings]->getKey(idx_out));
   TEST_ASSERT_NULL(settings[ID_Strings]->getHint(idx_out));
-  TEST_ASSERT_NULL(settings[ID_Strings]->getDefaultValueAs<const char*>(idx_out));
+  TEST_ASSERT_NULL(settings[ID_Strings]->getDefaultValueAs<NVS::StrView>(idx_out).data);
 
-  TEST_ASSERT_FALSE(settings[ID_Strings]->getValuePtr(idx_out, buffer, sizeof(buffer)));
-  settings[ID_Strings]->giveMutex();
+  NVS::Str oob{buffer, sizeof(buffer)};
+  TEST_ASSERT_FALSE(settings[ID_Strings]->getValuePtr(idx_out, &oob, sizeof(oob)));
 
   // Buffer too small
-  TEST_ASSERT_FALSE(settings[ID_Strings]->getValuePtr(0, buffer, 0));
-  settings[ID_Strings]->giveMutex();
+  NVS::Str tiny{buffer, 0};
+  TEST_ASSERT_FALSE(settings[ID_Strings]->getValuePtr(0, &tiny, sizeof(tiny)));
 
-  // NVS key not saved in the NVS yet, returns default value
+  // NVS key not saved yet - getValuePtr returns false and leaves the buffer unmodified
   uint8_t idx_nullptr = idx_out - 1;
-  TEST_ASSERT_TRUE(settings[ID_Strings]->getValuePtr(idx_nullptr, buffer, sizeof(buffer)));
-  settings[ID_Strings]->giveMutex();
-  TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(static_cast<Strings>(idx_nullptr)), buffer);
+  NVS::Str def_out{buffer, sizeof(buffer)};
+  TEST_ASSERT_FALSE(settings[ID_Strings]->getValuePtr(idx_nullptr, &def_out, sizeof(def_out)));
 }
 
 void test_strings_format() {
   TEST_ASSERT_EQUAL(0, strings.formatAll());
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_STRING(new_string[i], strings.getValue(static_cast<Strings>(i)));
-    strings.giveMutex();
+    char buf[32];
+    NVS::Str out{buf, sizeof(buf)};
+    TEST_ASSERT(strings.getValue(static_cast<Strings>(i), out));
+    TEST_ASSERT_EQUAL_STRING(new_string[i], out.data);
   }
 }
 
@@ -955,9 +1004,10 @@ void test_strings_forceFormat() {
   TEST_ASSERT_EQUAL(0, strings.formatAll(true));
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(static_cast<Strings>(i)),
-                             strings.getValue(static_cast<Strings>(i)));
-    strings.giveMutex();
+    char buf[32];
+    NVS::Str out{buf, sizeof(buf)};
+    TEST_ASSERT(strings.getValue(static_cast<Strings>(i), out));
+    TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(static_cast<Strings>(i)).data, out.data);
   }
 }
 /* ---------------------------------------------------------------------------------------------- */
@@ -974,7 +1024,7 @@ void test_bytestreams_getHint() {
 }
 
 void test_bytestreams_getDefaultValue() {
-  NVS::ByteStream default_value;
+  NVS::ByteStreamView default_value;
 
   default_value = bytestreams.getDefaultValue(ByteStreams::Stream_1);
   TEST_ASSERT_EQUAL_UINT32(bytestream1_default.size, default_value.size);
@@ -993,23 +1043,17 @@ void test_bytestreams_setValue() {
 }
 
 void test_bytestreams_getValue() {
-  NVS::ByteStream value;
+  uint8_t buf[32];
+  NVS::ByteStream value{buf, sizeof(buf)};
 
-  value = bytestreams.getValue(ByteStreams::Stream_1);
-  bytestreams.giveMutex();
+  TEST_ASSERT(bytestreams.getValue(ByteStreams::Stream_1, value));
   TEST_ASSERT_EQUAL_UINT32(new_bytestream[0].size, value.size);
   TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[0].data, value.data, value.size);
 
-  // Bytestream format is not changed. Check against the default format.
-  TEST_ASSERT_EQUAL(bytestream1_default.format, value.format);
-
-  value = bytestreams.getValue(ByteStreams::Stream_2);
-  bytestreams.giveMutex();
+  value = {buf, sizeof(buf)};
+  TEST_ASSERT(bytestreams.getValue(ByteStreams::Stream_2, value));
   TEST_ASSERT_EQUAL_UINT32(new_bytestream[1].size, value.size);
   TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[1].data, value.data, value.size);
-
-  // Bytestream format is not changed. Check against the default format.
-  TEST_ASSERT_EQUAL(bytestream2_default.format, value.format);
 }
 
 void test_bytestreams_hasKey() {
@@ -1024,36 +1068,37 @@ void test_bytestreams_hasKey() {
 void test_bytestreams_pointer() {
   TEST_ASSERT_EQUAL(NVS::Type::ByteStream, settings[ID_ByteStreams]->getType());
 
-  char buffer[64];
+  char key_buf[64];
+  uint8_t blob_buf[64];
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
     // Key
-    sprintf(buffer, "Stream_%u", i + 1);
-    TEST_ASSERT_EQUAL_STRING(buffer, settings[ID_ByteStreams]->getKey(i));
+    sprintf(key_buf, "Stream_%u", i + 1);
+    TEST_ASSERT_EQUAL_STRING(key_buf, settings[ID_ByteStreams]->getKey(i));
 
     // Hint
-    sprintf(buffer, "My ByteStream %u", i + 1);
-    TEST_ASSERT_EQUAL_STRING(buffer, settings[ID_ByteStreams]->getHint(i));
+    sprintf(key_buf, "My ByteStream %u", i + 1);
+    TEST_ASSERT_EQUAL_STRING(key_buf, settings[ID_ByteStreams]->getHint(i));
 
-    // Value
-    NVS::ByteStream value;
-    TEST_ASSERT_TRUE(settings[ID_ByteStreams]->getValuePtr(i, &value, sizeof(value)));
-    settings[ID_ByteStreams]->giveMutex();
+    // Value via pointer interface
+    NVS::ByteStream ptr_value{blob_buf, sizeof(blob_buf)};
+    TEST_ASSERT_TRUE(settings[ID_ByteStreams]->getValuePtr(i, &ptr_value, sizeof(ptr_value)));
 
-    TEST_ASSERT_EQUAL_UINT32(bytestreams.getValue(static_cast<ByteStreams>(i)).size, value.size);
-    settings[ID_ByteStreams]->giveMutex();
+    uint8_t ref_buf[64];
+    NVS::ByteStream ref_value{ref_buf, sizeof(ref_buf)};
+    bytestreams.getValue(static_cast<ByteStreams>(i), ref_value);
 
-    TEST_ASSERT_EQUAL_HEX8_ARRAY(
-      bytestreams.getValue(static_cast<ByteStreams>(i)).data, value.data, value.size);
-    settings[ID_ByteStreams]->giveMutex();
+    TEST_ASSERT_EQUAL_UINT32(ref_value.size, ptr_value.size);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(ref_value.data, ptr_value.data, ptr_value.size);
 
     // Default value
-    TEST_ASSERT_EQUAL_UINT32(bytestreams.getDefaultValue(static_cast<ByteStreams>(i)).size,
-                             settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStream>(i).size);
+    TEST_ASSERT_EQUAL_UINT32(
+      bytestreams.getDefaultValue(static_cast<ByteStreams>(i)).size,
+      settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStreamView>(i).size);
     TEST_ASSERT_EQUAL_HEX8_ARRAY(
       bytestreams.getDefaultValue(static_cast<ByteStreams>(i)).data,
-      settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStream>(i).data,
-      settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStream>(i).size);
+      settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStreamView>(i).data,
+      settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStreamView>(i).size);
   }
 
   // Index out of bounds
@@ -1062,45 +1107,34 @@ void test_bytestreams_pointer() {
   TEST_ASSERT_NULL(settings[ID_ByteStreams]->getKey(idx_out));
   TEST_ASSERT_NULL(settings[ID_ByteStreams]->getHint(idx_out));
 
-  NVS::ByteStream def_value;
-  def_value = settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStream>(idx_out);
+  NVS::ByteStreamView def_value;
+  def_value = settings[ID_ByteStreams]->getDefaultValueAs<NVS::ByteStreamView>(idx_out);
   TEST_ASSERT_NULL(def_value.data);
   TEST_ASSERT_EQUAL_UINT32(0, def_value.size);
 
-  NVS::ByteStream value;
+  NVS::ByteStream value{blob_buf, sizeof(blob_buf)};
   TEST_ASSERT_FALSE(settings[ID_ByteStreams]->getValuePtr(idx_out, &value, sizeof(value)));
-  settings[ID_ByteStreams]->giveMutex();
 
-  // Buffer too small
-  TEST_ASSERT_FALSE(settings[ID_ByteStreams]->getValuePtr(0, &value, 0));
-  settings[ID_ByteStreams]->giveMutex();
+  // Buffer too small for the blob (size=0 means 0-capacity buffer in our struct)
+  NVS::ByteStream tiny{blob_buf, 0};
+  TEST_ASSERT_FALSE(settings[ID_ByteStreams]->getValuePtr(0, &tiny, sizeof(tiny)));
 
-  // NVS key not saved in the NVS yet, returns default value
+  // NVS key not saved yet - getValuePtr returns false and leaves the buffer unmodified
   uint8_t idx_nullptr = idx_out - 1;
-  TEST_ASSERT_TRUE(settings[ID_ByteStreams]->getValuePtr(idx_nullptr, &value, sizeof(value)));
-  settings[ID_ByteStreams]->giveMutex();
-
-  TEST_ASSERT_EQUAL_UINT32(bytestreams.getDefaultValue(static_cast<ByteStreams>(idx_nullptr)).size,
-                           value.size);
-  TEST_ASSERT_EQUAL_HEX8_ARRAY(
-    bytestreams.getDefaultValue(static_cast<ByteStreams>(idx_nullptr)).data,
-    value.data,
-    value.size);
+  NVS::ByteStream def_out{blob_buf, sizeof(blob_buf)};
+  TEST_ASSERT_FALSE(settings[ID_ByteStreams]->getValuePtr(idx_nullptr, &def_out, sizeof(def_out)));
 }
 
 void test_bytestreams_format() {
   TEST_ASSERT_EQUAL(0, bytestreams.formatAll());
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    NVS::ByteStream value = bytestreams.getValue(static_cast<ByteStreams>(i));
-    bytestreams.giveMutex();
+    uint8_t buf[32];
+    NVS::ByteStream value{buf, sizeof(buf)};
+    TEST_ASSERT(bytestreams.getValue(static_cast<ByteStreams>(i), value));
 
     TEST_ASSERT_EQUAL_UINT32(new_bytestream[i].size, value.size);
     TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[i].data, value.data, value.size);
-
-    // Bytestream format is not changed. Check against the default format.
-    TEST_ASSERT_EQUAL(bytestreams.getDefaultValue(static_cast<ByteStreams>(i)).format,
-                      value.format);
   }
 }
 
@@ -1108,17 +1142,14 @@ void test_bytestreams_forceFormat() {
   TEST_ASSERT_EQUAL(0, bytestreams.formatAll(true));
 
   for (size_t i = 0; i < NVS_VALUES; i++) {
-    NVS::ByteStream value = bytestreams.getValue(static_cast<ByteStreams>(i));
-    bytestreams.giveMutex();
+    uint8_t buf[32];
+    NVS::ByteStream value{buf, sizeof(buf)};
+    TEST_ASSERT(bytestreams.getValue(static_cast<ByteStreams>(i), value));
 
     TEST_ASSERT_EQUAL_UINT32(bytestreams.getDefaultValue(static_cast<ByteStreams>(i)).size,
                              value.size);
     TEST_ASSERT_EQUAL_HEX8_ARRAY(
       bytestreams.getDefaultValue(static_cast<ByteStreams>(i)).data, value.data, value.size);
-
-    // Bytestream format is not changed. Check against the default format.
-    TEST_ASSERT_EQUAL(bytestreams.getDefaultValue(static_cast<ByteStreams>(i)).format,
-                      value.format);
   }
 }
 /* ---------------------------------------------------------------------------------------------- */

--- a/test/test_settings.cpp
+++ b/test/test_settings.cpp
@@ -181,6 +181,8 @@ void test_bools_setValue();
 void test_bools_getValue();
 void test_bools_hasKey();
 void test_bools_pointer();
+void test_bools_getValueOrDefault();
+void test_bools_getValuePtrOrDefault();
 void test_bools_format();
 void test_bools_forceFormat();
 
@@ -191,6 +193,8 @@ void test_uint32s_setValue();
 void test_uint32s_getValue();
 void test_uint32s_hasKey();
 void test_uint32s_pointer();
+void test_uint32s_getValueOrDefault();
+void test_uint32s_getValuePtrOrDefault();
 void test_uint32s_format();
 void test_uint32s_forceFormat();
 
@@ -201,6 +205,8 @@ void test_int32s_setValue();
 void test_int32s_getValue();
 void test_int32s_hasKey();
 void test_int32s_pointer();
+void test_int32s_getValueOrDefault();
+void test_int32s_getValuePtrOrDefault();
 void test_int32s_format();
 void test_int32s_forceFormat();
 
@@ -211,6 +217,8 @@ void test_floats_setValue();
 void test_floats_getValue();
 void test_floats_hasKey();
 void test_floats_pointer();
+void test_floats_getValueOrDefault();
+void test_floats_getValuePtrOrDefault();
 void test_floats_format();
 void test_floats_forceFormat();
 
@@ -221,6 +229,8 @@ void test_doubles_setValue();
 void test_doubles_getValue();
 void test_doubles_hasKey();
 void test_doubles_pointer();
+void test_doubles_getValueOrDefault();
+void test_doubles_getValuePtrOrDefault();
 void test_doubles_format();
 void test_doubles_forceFormat();
 
@@ -231,6 +241,8 @@ void test_strings_setValue();
 void test_strings_getValue();
 void test_strings_hasKey();
 void test_strings_pointer();
+void test_strings_getValueOrDefault();
+void test_strings_getValuePtrOrDefault();
 void test_strings_format();
 void test_strings_forceFormat();
 
@@ -241,6 +253,8 @@ void test_bytestreams_setValue();
 void test_bytestreams_getValue();
 void test_bytestreams_hasKey();
 void test_bytestreams_pointer();
+void test_bytestreams_getValueOrDefault();
+void test_bytestreams_getValuePtrOrDefault();
 void test_bytestreams_format();
 void test_bytestreams_forceFormat();
 
@@ -280,6 +294,8 @@ void setup() {
   RUN_TEST(test_bools_getValue);
   RUN_TEST(test_bools_hasKey);
   RUN_TEST(test_bools_pointer);
+  RUN_TEST(test_bools_getValueOrDefault);
+  RUN_TEST(test_bools_getValuePtrOrDefault);
   RUN_TEST(test_bools_format);
   RUN_TEST(test_bools_forceFormat);
 
@@ -290,6 +306,8 @@ void setup() {
   RUN_TEST(test_uint32s_getValue);
   RUN_TEST(test_uint32s_hasKey);
   RUN_TEST(test_uint32s_pointer);
+  RUN_TEST(test_uint32s_getValueOrDefault);
+  RUN_TEST(test_uint32s_getValuePtrOrDefault);
   RUN_TEST(test_uint32s_format);
   RUN_TEST(test_uint32s_forceFormat);
 
@@ -300,6 +318,8 @@ void setup() {
   RUN_TEST(test_int32s_getValue);
   RUN_TEST(test_int32s_hasKey);
   RUN_TEST(test_int32s_pointer);
+  RUN_TEST(test_int32s_getValueOrDefault);
+  RUN_TEST(test_int32s_getValuePtrOrDefault);
   RUN_TEST(test_int32s_format);
   RUN_TEST(test_int32s_forceFormat);
 
@@ -310,6 +330,8 @@ void setup() {
   RUN_TEST(test_floats_getValue);
   RUN_TEST(test_floats_hasKey);
   RUN_TEST(test_floats_pointer);
+  RUN_TEST(test_floats_getValueOrDefault);
+  RUN_TEST(test_floats_getValuePtrOrDefault);
   RUN_TEST(test_floats_format);
   RUN_TEST(test_floats_forceFormat);
 
@@ -320,6 +342,8 @@ void setup() {
   RUN_TEST(test_doubles_getValue);
   RUN_TEST(test_doubles_hasKey);
   RUN_TEST(test_doubles_pointer);
+  RUN_TEST(test_doubles_getValueOrDefault);
+  RUN_TEST(test_doubles_getValuePtrOrDefault);
   RUN_TEST(test_doubles_format);
   RUN_TEST(test_doubles_forceFormat);
 
@@ -330,6 +354,8 @@ void setup() {
   RUN_TEST(test_strings_getValue);
   RUN_TEST(test_strings_hasKey);
   RUN_TEST(test_strings_pointer);
+  RUN_TEST(test_strings_getValueOrDefault);
+  RUN_TEST(test_strings_getValuePtrOrDefault);
   RUN_TEST(test_strings_format);
   RUN_TEST(test_strings_forceFormat);
 
@@ -340,6 +366,8 @@ void setup() {
   RUN_TEST(test_bytestreams_getValue);
   RUN_TEST(test_bytestreams_hasKey);
   RUN_TEST(test_bytestreams_pointer);
+  RUN_TEST(test_bytestreams_getValueOrDefault);
+  RUN_TEST(test_bytestreams_getValuePtrOrDefault);
   RUN_TEST(test_bytestreams_format);
   RUN_TEST(test_bytestreams_forceFormat);
 
@@ -469,6 +497,44 @@ void test_bools_pointer() {
   TEST_ASSERT_FALSE(settings[ID_Bools]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
+void test_bools_getValueOrDefault() {
+  bool out;
+
+  // Key exists in NVS (Bool_1 after setValue): should return the NVS value
+  bool result = bools.getValueOrDefault(Bools::Bool_1, out);
+  TEST_ASSERT_EQUAL(new_bool[0], result);
+  TEST_ASSERT_EQUAL(new_bool[0], out);
+
+  // Key not in NVS (Bool_3 was never written): should return the default value
+  result = bools.getValueOrDefault(Bools::Bool_3, out);
+  TEST_ASSERT_EQUAL(bools.getDefaultValue(Bools::Bool_3), result);
+  TEST_ASSERT_EQUAL(bools.getDefaultValue(Bools::Bool_3), out);
+}
+
+void test_bools_getValuePtrOrDefault() {
+  bool out;
+  const void* result;
+
+  // Key exists in NVS (index 0 = Bool_1): returns non-null pointer to the NVS value
+  result = settings[ID_Bools]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL(new_bool[0], *static_cast<const bool*>(result));
+  TEST_ASSERT_EQUAL(new_bool[0], out);
+
+  // Key not in NVS (index 2 = Bool_3): returns non-null pointer to the default value
+  result = settings[ID_Bools]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL(bools.getDefaultValue(Bools::Bool_3), *static_cast<const bool*>(result));
+  TEST_ASSERT_EQUAL(bools.getDefaultValue(Bools::Bool_3), out);
+
+  // Index out of bounds: returns nullptr
+  TEST_ASSERT_NULL(
+    settings[ID_Bools]->getValuePtrOrDefault(settings[ID_Bools]->getSize(), &out, sizeof(out)));
+
+  // Buffer too small: returns nullptr
+  TEST_ASSERT_NULL(settings[ID_Bools]->getValuePtrOrDefault(0, &out, 0));
+}
+
 void test_bools_format() {
   TEST_ASSERT_EQUAL(0, bools.formatAll());
 
@@ -570,6 +636,45 @@ void test_uint32s_pointer() {
   // NVS key not saved yet - getValuePtr returns false and leaves value unmodified
   uint8_t idx_nullptr = idx_out - 1;
   TEST_ASSERT_FALSE(settings[ID_UInt32s]->getValuePtr(idx_nullptr, &value, sizeof(value)));
+}
+
+void test_uint32s_getValueOrDefault() {
+  uint32_t out;
+
+  // Key exists in NVS (UInt32_1 = 11 after setValue): should return the NVS value
+  uint32_t result = uint32s.getValueOrDefault(UInt32s::UInt32_1, out);
+  TEST_ASSERT_EQUAL_UINT32(new_uint32[0], result);
+  TEST_ASSERT_EQUAL_UINT32(new_uint32[0], out);
+
+  // Key not in NVS (UInt32_3 was never written): should return the default value
+  result = uint32s.getValueOrDefault(UInt32s::UInt32_3, out);
+  TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(UInt32s::UInt32_3), result);
+  TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(UInt32s::UInt32_3), out);
+}
+
+void test_uint32s_getValuePtrOrDefault() {
+  uint32_t out;
+  const void* result;
+
+  // Key exists in NVS (index 0 = UInt32_1 = 11): returns non-null pointer to the NVS value
+  result = settings[ID_UInt32s]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_UINT32(new_uint32[0], *static_cast<const uint32_t*>(result));
+  TEST_ASSERT_EQUAL_UINT32(new_uint32[0], out);
+
+  // Key not in NVS (index 2 = UInt32_3): returns non-null pointer to the default value
+  result = settings[ID_UInt32s]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(UInt32s::UInt32_3),
+                           *static_cast<const uint32_t*>(result));
+  TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(UInt32s::UInt32_3), out);
+
+  // Index out of bounds: returns nullptr
+  TEST_ASSERT_NULL(
+    settings[ID_UInt32s]->getValuePtrOrDefault(settings[ID_UInt32s]->getSize(), &out, sizeof(out)));
+
+  // Buffer too small: returns nullptr
+  TEST_ASSERT_NULL(settings[ID_UInt32s]->getValuePtrOrDefault(0, &out, 0));
 }
 
 void test_uint32s_format() {
@@ -675,6 +780,45 @@ void test_int32s_pointer() {
   TEST_ASSERT_FALSE(settings[ID_Int32s]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
+void test_int32s_getValueOrDefault() {
+  int32_t out;
+
+  // Key exists in NVS (Int32_1 after setValue): should return the NVS value
+  int32_t result = int32s.getValueOrDefault(Int32s::Int32_1, out);
+  TEST_ASSERT_EQUAL_INT32(new_int32[0], result);
+  TEST_ASSERT_EQUAL_INT32(new_int32[0], out);
+
+  // Key not in NVS (Int32_3 was never written): should return the default value
+  result = int32s.getValueOrDefault(Int32s::Int32_3, out);
+  TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(Int32s::Int32_3), result);
+  TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(Int32s::Int32_3), out);
+}
+
+void test_int32s_getValuePtrOrDefault() {
+  int32_t out;
+  const void* result;
+
+  // Key exists in NVS (index 0 = Int32_1): returns non-null pointer to the NVS value
+  result = settings[ID_Int32s]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_INT32(new_int32[0], *static_cast<const int32_t*>(result));
+  TEST_ASSERT_EQUAL_INT32(new_int32[0], out);
+
+  // Key not in NVS (index 2 = Int32_3): returns non-null pointer to the default value
+  result = settings[ID_Int32s]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(Int32s::Int32_3),
+                          *static_cast<const int32_t*>(result));
+  TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(Int32s::Int32_3), out);
+
+  // Index out of bounds: returns nullptr
+  TEST_ASSERT_NULL(
+    settings[ID_Int32s]->getValuePtrOrDefault(settings[ID_Int32s]->getSize(), &out, sizeof(out)));
+
+  // Buffer too small: returns nullptr
+  TEST_ASSERT_NULL(settings[ID_Int32s]->getValuePtrOrDefault(0, &out, 0));
+}
+
 void test_int32s_format() {
   TEST_ASSERT_EQUAL(0, int32s.formatAll());
 
@@ -778,6 +922,45 @@ void test_floats_pointer() {
   TEST_ASSERT_FALSE(settings[ID_Floats]->getValuePtr(idx_nullptr, &value, sizeof(value)));
 }
 
+void test_floats_getValueOrDefault() {
+  float out;
+
+  // Key exists in NVS (Float_1 after setValue): should return the NVS value
+  float result = floats.getValueOrDefault(Floats::Float_1, out);
+  TEST_ASSERT_EQUAL_FLOAT(new_float[0], result);
+  TEST_ASSERT_EQUAL_FLOAT(new_float[0], out);
+
+  // Key not in NVS (Float_3 was never written): should return the default value
+  result = floats.getValueOrDefault(Floats::Float_3, out);
+  TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(Floats::Float_3), result);
+  TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(Floats::Float_3), out);
+}
+
+void test_floats_getValuePtrOrDefault() {
+  float out;
+  const void* result;
+
+  // Key exists in NVS (index 0 = Float_1): returns non-null pointer to the NVS value
+  result = settings[ID_Floats]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_FLOAT(new_float[0], *static_cast<const float*>(result));
+  TEST_ASSERT_EQUAL_FLOAT(new_float[0], out);
+
+  // Key not in NVS (index 2 = Float_3): returns non-null pointer to the default value
+  result = settings[ID_Floats]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(Floats::Float_3),
+                          *static_cast<const float*>(result));
+  TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(Floats::Float_3), out);
+
+  // Index out of bounds: returns nullptr
+  TEST_ASSERT_NULL(
+    settings[ID_Floats]->getValuePtrOrDefault(settings[ID_Floats]->getSize(), &out, sizeof(out)));
+
+  // Buffer too small: returns nullptr
+  TEST_ASSERT_NULL(settings[ID_Floats]->getValuePtrOrDefault(0, &out, 0));
+}
+
 void test_floats_format() {
   TEST_ASSERT_EQUAL(0, floats.formatAll());
 
@@ -879,6 +1062,45 @@ void test_doubles_pointer() {
   // NVS key not saved yet - getValuePtr returns false and leaves value unmodified
   uint8_t idx_nullptr = idx_out - 1;
   TEST_ASSERT_FALSE(settings[ID_Doubles]->getValuePtr(idx_nullptr, &value, sizeof(value)));
+}
+
+void test_doubles_getValueOrDefault() {
+  double out;
+
+  // Key exists in NVS (Double_1 after setValue): should return the NVS value
+  double result = doubles.getValueOrDefault(Doubles::Double_1, out);
+  TEST_ASSERT_EQUAL_DOUBLE(new_double[0], result);
+  TEST_ASSERT_EQUAL_DOUBLE(new_double[0], out);
+
+  // Key not in NVS (Double_3 was never written): should return the default value
+  result = doubles.getValueOrDefault(Doubles::Double_3, out);
+  TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(Doubles::Double_3), result);
+  TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(Doubles::Double_3), out);
+}
+
+void test_doubles_getValuePtrOrDefault() {
+  double out;
+  const void* result;
+
+  // Key exists in NVS (index 0 = Double_1): returns non-null pointer to the NVS value
+  result = settings[ID_Doubles]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_DOUBLE(new_double[0], *static_cast<const double*>(result));
+  TEST_ASSERT_EQUAL_DOUBLE(new_double[0], out);
+
+  // Key not in NVS (index 2 = Double_3): returns non-null pointer to the default value
+  result = settings[ID_Doubles]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(Doubles::Double_3),
+                           *static_cast<const double*>(result));
+  TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(Doubles::Double_3), out);
+
+  // Index out of bounds: returns nullptr
+  TEST_ASSERT_NULL(
+    settings[ID_Doubles]->getValuePtrOrDefault(settings[ID_Doubles]->getSize(), &out, sizeof(out)));
+
+  // Buffer too small: returns nullptr
+  TEST_ASSERT_NULL(settings[ID_Doubles]->getValuePtrOrDefault(0, &out, 0));
 }
 
 void test_doubles_format() {
@@ -987,6 +1209,50 @@ void test_strings_pointer() {
   uint8_t idx_nullptr = idx_out - 1;
   NVS::Str def_out{buffer, sizeof(buffer)};
   TEST_ASSERT_FALSE(settings[ID_Strings]->getValuePtr(idx_nullptr, &def_out, sizeof(def_out)));
+}
+
+void test_strings_getValueOrDefault() {
+  char buf[32];
+  NVS::Str out{buf, sizeof(buf)};
+
+  // Key exists in NVS (String_1 after setValue): should return the NVS value
+  NVS::Str result = strings.getValueOrDefault(Strings::String_1, out);
+  TEST_ASSERT_EQUAL_STRING(new_string[0], result.data);
+  TEST_ASSERT_EQUAL_STRING(new_string[0], out.data);
+
+  // Key not in NVS (String_3 was never written): should return the default value
+  out    = {buf, sizeof(buf)};
+  result = strings.getValueOrDefault(Strings::String_3, out);
+  TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(Strings::String_3).data, result.data);
+  TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(Strings::String_3).data, out.data);
+}
+
+void test_strings_getValuePtrOrDefault() {
+  char buf[32];
+  NVS::Str out{buf, sizeof(buf)};
+  const void* result;
+
+  // Key exists in NVS (index 0 = String_1): returns non-null pointer to the NVS value
+  result = settings[ID_Strings]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_STRING(new_string[0], static_cast<const NVS::Str*>(result)->data);
+  TEST_ASSERT_EQUAL_STRING(new_string[0], out.data);
+
+  // Key not in NVS (index 2 = String_3): returns non-null pointer to the default value
+  out    = {buf, sizeof(buf)};
+  result = settings[ID_Strings]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(Strings::String_3).data,
+                           static_cast<const NVS::Str*>(result)->data);
+  TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(Strings::String_3).data, out.data);
+
+  // Index out of bounds: returns nullptr
+  TEST_ASSERT_NULL(
+    settings[ID_Strings]->getValuePtrOrDefault(settings[ID_Strings]->getSize(), &out, sizeof(out)));
+
+  // Buffer too small (size field = 0): returns nullptr
+  NVS::Str tiny{buf, 0};
+  TEST_ASSERT_NULL(settings[ID_Strings]->getValuePtrOrDefault(0, &tiny, 0));
 }
 
 void test_strings_format() {
@@ -1123,6 +1389,61 @@ void test_bytestreams_pointer() {
   uint8_t idx_nullptr = idx_out - 1;
   NVS::ByteStream def_out{blob_buf, sizeof(blob_buf)};
   TEST_ASSERT_FALSE(settings[ID_ByteStreams]->getValuePtr(idx_nullptr, &def_out, sizeof(def_out)));
+}
+
+void test_bytestreams_getValueOrDefault() {
+  uint8_t buf[32];
+  NVS::ByteStream out{buf, sizeof(buf)};
+
+  // Key exists in NVS (Stream_1 after setValue): should return the NVS value
+  NVS::ByteStream result = bytestreams.getValueOrDefault(ByteStreams::Stream_1, out);
+  TEST_ASSERT_EQUAL_UINT32(new_bytestream[0].size, result.size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[0].data, result.data, result.size);
+  TEST_ASSERT_EQUAL_UINT32(new_bytestream[0].size, out.size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[0].data, out.data, out.size);
+
+  // Key not in NVS (Stream_3 was never written): should return the default value
+  out                      = {buf, sizeof(buf)};
+  result                   = bytestreams.getValueOrDefault(ByteStreams::Stream_3, out);
+  NVS::ByteStreamView def3 = bytestreams.getDefaultValue(ByteStreams::Stream_3);
+  TEST_ASSERT_EQUAL_UINT32(def3.size, result.size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(def3.data, result.data, result.size);
+  TEST_ASSERT_EQUAL_UINT32(def3.size, out.size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(def3.data, out.data, out.size);
+}
+
+void test_bytestreams_getValuePtrOrDefault() {
+  uint8_t buf[32];
+  NVS::ByteStream out{buf, sizeof(buf)};
+  const void* result;
+
+  // Key exists in NVS (index 0 = Stream_1): returns non-null pointer to the NVS value
+  result = settings[ID_ByteStreams]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  TEST_ASSERT_EQUAL_UINT32(new_bytestream[0].size,
+                           static_cast<const NVS::ByteStream*>(result)->size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[0].data,
+                               static_cast<const NVS::ByteStream*>(result)->data,
+                               new_bytestream[0].size);
+
+  // Key not in NVS (index 2 = Stream_3): returns non-null pointer to the default value
+  out    = {buf, sizeof(buf)};
+  result = settings[ID_ByteStreams]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_NOT_NULL(result);
+  NVS::ByteStreamView def3 = bytestreams.getDefaultValue(ByteStreams::Stream_3);
+  TEST_ASSERT_EQUAL_UINT32(def3.size, static_cast<const NVS::ByteStream*>(result)->size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(
+    def3.data, static_cast<const NVS::ByteStream*>(result)->data, def3.size);
+  TEST_ASSERT_EQUAL_UINT32(def3.size, out.size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(def3.data, out.data, out.size);
+
+  // Index out of bounds: returns nullptr
+  TEST_ASSERT_NULL(settings[ID_ByteStreams]->getValuePtrOrDefault(
+    settings[ID_ByteStreams]->getSize(), &out, sizeof(out)));
+
+  // Buffer too small (max_size = 0): returns nullptr
+  NVS::ByteStream tiny{buf, 0};
+  TEST_ASSERT_NULL(settings[ID_ByteStreams]->getValuePtrOrDefault(0, &tiny, 0));
 }
 
 void test_bytestreams_format() {

--- a/test/test_settings.cpp
+++ b/test/test_settings.cpp
@@ -513,26 +513,24 @@ void test_bools_getValueOrDefault() {
 
 void test_bools_getValuePtrOrDefault() {
   bool out;
-  const void* result;
+  bool ok;
 
-  // Key exists in NVS (index 0 = Bool_1): returns non-null pointer to the NVS value
-  result = settings[ID_Bools]->getValuePtrOrDefault(0, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL(new_bool[0], *static_cast<const bool*>(result));
+  // Key exists in NVS (index 0 = Bool_1): returns true, out holds the NVS value
+  ok = settings[ID_Bools]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL(new_bool[0], out);
 
-  // Key not in NVS (index 2 = Bool_3): returns non-null pointer to the default value
-  result = settings[ID_Bools]->getValuePtrOrDefault(2, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL(bools.getDefaultValue(Bools::Bool_3), *static_cast<const bool*>(result));
+  // Key not in NVS (index 2 = Bool_3): returns true, out holds the default value
+  ok = settings[ID_Bools]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL(bools.getDefaultValue(Bools::Bool_3), out);
 
-  // Index out of bounds: returns nullptr
-  TEST_ASSERT_NULL(
+  // Index out of bounds: returns false
+  TEST_ASSERT_FALSE(
     settings[ID_Bools]->getValuePtrOrDefault(settings[ID_Bools]->getSize(), &out, sizeof(out)));
 
-  // Buffer too small: returns nullptr
-  TEST_ASSERT_NULL(settings[ID_Bools]->getValuePtrOrDefault(0, &out, 0));
+  // Buffer too small: returns false
+  TEST_ASSERT_FALSE(settings[ID_Bools]->getValuePtrOrDefault(0, &out, 0));
 }
 
 void test_bools_format() {
@@ -654,27 +652,24 @@ void test_uint32s_getValueOrDefault() {
 
 void test_uint32s_getValuePtrOrDefault() {
   uint32_t out;
-  const void* result;
+  bool ok;
 
-  // Key exists in NVS (index 0 = UInt32_1 = 11): returns non-null pointer to the NVS value
-  result = settings[ID_UInt32s]->getValuePtrOrDefault(0, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_UINT32(new_uint32[0], *static_cast<const uint32_t*>(result));
+  // Key exists in NVS (index 0 = UInt32_1 = 11): returns true, out holds the NVS value
+  ok = settings[ID_UInt32s]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_UINT32(new_uint32[0], out);
 
-  // Key not in NVS (index 2 = UInt32_3): returns non-null pointer to the default value
-  result = settings[ID_UInt32s]->getValuePtrOrDefault(2, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(UInt32s::UInt32_3),
-                           *static_cast<const uint32_t*>(result));
+  // Key not in NVS (index 2 = UInt32_3): returns true, out holds the default value
+  ok = settings[ID_UInt32s]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_UINT32(uint32s.getDefaultValue(UInt32s::UInt32_3), out);
 
-  // Index out of bounds: returns nullptr
-  TEST_ASSERT_NULL(
+  // Index out of bounds: returns false
+  TEST_ASSERT_FALSE(
     settings[ID_UInt32s]->getValuePtrOrDefault(settings[ID_UInt32s]->getSize(), &out, sizeof(out)));
 
-  // Buffer too small: returns nullptr
-  TEST_ASSERT_NULL(settings[ID_UInt32s]->getValuePtrOrDefault(0, &out, 0));
+  // Buffer too small: returns false
+  TEST_ASSERT_FALSE(settings[ID_UInt32s]->getValuePtrOrDefault(0, &out, 0));
 }
 
 void test_uint32s_format() {
@@ -796,27 +791,24 @@ void test_int32s_getValueOrDefault() {
 
 void test_int32s_getValuePtrOrDefault() {
   int32_t out;
-  const void* result;
+  bool ok;
 
-  // Key exists in NVS (index 0 = Int32_1): returns non-null pointer to the NVS value
-  result = settings[ID_Int32s]->getValuePtrOrDefault(0, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_INT32(new_int32[0], *static_cast<const int32_t*>(result));
+  // Key exists in NVS (index 0 = Int32_1): returns true, out holds the NVS value
+  ok = settings[ID_Int32s]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_INT32(new_int32[0], out);
 
-  // Key not in NVS (index 2 = Int32_3): returns non-null pointer to the default value
-  result = settings[ID_Int32s]->getValuePtrOrDefault(2, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(Int32s::Int32_3),
-                          *static_cast<const int32_t*>(result));
+  // Key not in NVS (index 2 = Int32_3): returns true, out holds the default value
+  ok = settings[ID_Int32s]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_INT32(int32s.getDefaultValue(Int32s::Int32_3), out);
 
-  // Index out of bounds: returns nullptr
-  TEST_ASSERT_NULL(
+  // Index out of bounds: returns false
+  TEST_ASSERT_FALSE(
     settings[ID_Int32s]->getValuePtrOrDefault(settings[ID_Int32s]->getSize(), &out, sizeof(out)));
 
-  // Buffer too small: returns nullptr
-  TEST_ASSERT_NULL(settings[ID_Int32s]->getValuePtrOrDefault(0, &out, 0));
+  // Buffer too small: returns false
+  TEST_ASSERT_FALSE(settings[ID_Int32s]->getValuePtrOrDefault(0, &out, 0));
 }
 
 void test_int32s_format() {
@@ -938,27 +930,24 @@ void test_floats_getValueOrDefault() {
 
 void test_floats_getValuePtrOrDefault() {
   float out;
-  const void* result;
+  bool ok;
 
-  // Key exists in NVS (index 0 = Float_1): returns non-null pointer to the NVS value
-  result = settings[ID_Floats]->getValuePtrOrDefault(0, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_FLOAT(new_float[0], *static_cast<const float*>(result));
+  // Key exists in NVS (index 0 = Float_1): returns true, out holds the NVS value
+  ok = settings[ID_Floats]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_FLOAT(new_float[0], out);
 
-  // Key not in NVS (index 2 = Float_3): returns non-null pointer to the default value
-  result = settings[ID_Floats]->getValuePtrOrDefault(2, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(Floats::Float_3),
-                          *static_cast<const float*>(result));
+  // Key not in NVS (index 2 = Float_3): returns true, out holds the default value
+  ok = settings[ID_Floats]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_FLOAT(floats.getDefaultValue(Floats::Float_3), out);
 
-  // Index out of bounds: returns nullptr
-  TEST_ASSERT_NULL(
+  // Index out of bounds: returns false
+  TEST_ASSERT_FALSE(
     settings[ID_Floats]->getValuePtrOrDefault(settings[ID_Floats]->getSize(), &out, sizeof(out)));
 
-  // Buffer too small: returns nullptr
-  TEST_ASSERT_NULL(settings[ID_Floats]->getValuePtrOrDefault(0, &out, 0));
+  // Buffer too small: returns false
+  TEST_ASSERT_FALSE(settings[ID_Floats]->getValuePtrOrDefault(0, &out, 0));
 }
 
 void test_floats_format() {
@@ -1080,27 +1069,24 @@ void test_doubles_getValueOrDefault() {
 
 void test_doubles_getValuePtrOrDefault() {
   double out;
-  const void* result;
+  bool ok;
 
-  // Key exists in NVS (index 0 = Double_1): returns non-null pointer to the NVS value
-  result = settings[ID_Doubles]->getValuePtrOrDefault(0, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_DOUBLE(new_double[0], *static_cast<const double*>(result));
+  // Key exists in NVS (index 0 = Double_1): returns true, out holds the NVS value
+  ok = settings[ID_Doubles]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_DOUBLE(new_double[0], out);
 
-  // Key not in NVS (index 2 = Double_3): returns non-null pointer to the default value
-  result = settings[ID_Doubles]->getValuePtrOrDefault(2, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(Doubles::Double_3),
-                           *static_cast<const double*>(result));
+  // Key not in NVS (index 2 = Double_3): returns true, out holds the default value
+  ok = settings[ID_Doubles]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_DOUBLE(doubles.getDefaultValue(Doubles::Double_3), out);
 
-  // Index out of bounds: returns nullptr
-  TEST_ASSERT_NULL(
+  // Index out of bounds: returns false
+  TEST_ASSERT_FALSE(
     settings[ID_Doubles]->getValuePtrOrDefault(settings[ID_Doubles]->getSize(), &out, sizeof(out)));
 
-  // Buffer too small: returns nullptr
-  TEST_ASSERT_NULL(settings[ID_Doubles]->getValuePtrOrDefault(0, &out, 0));
+  // Buffer too small: returns false
+  TEST_ASSERT_FALSE(settings[ID_Doubles]->getValuePtrOrDefault(0, &out, 0));
 }
 
 void test_doubles_format() {
@@ -1230,29 +1216,26 @@ void test_strings_getValueOrDefault() {
 void test_strings_getValuePtrOrDefault() {
   char buf[32];
   NVS::Str out{buf, sizeof(buf)};
-  const void* result;
+  bool ok;
 
-  // Key exists in NVS (index 0 = String_1): returns non-null pointer to the NVS value
-  result = settings[ID_Strings]->getValuePtrOrDefault(0, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_STRING(new_string[0], static_cast<const NVS::Str*>(result)->data);
+  // Key exists in NVS (index 0 = String_1): returns true, out holds the NVS value
+  ok = settings[ID_Strings]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_STRING(new_string[0], out.data);
 
-  // Key not in NVS (index 2 = String_3): returns non-null pointer to the default value
-  out    = {buf, sizeof(buf)};
-  result = settings[ID_Strings]->getValuePtrOrDefault(2, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(Strings::String_3).data,
-                           static_cast<const NVS::Str*>(result)->data);
+  // Key not in NVS (index 2 = String_3): returns true, out holds the default value
+  out = {buf, sizeof(buf)};
+  ok  = settings[ID_Strings]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   TEST_ASSERT_EQUAL_STRING(strings.getDefaultValue(Strings::String_3).data, out.data);
 
-  // Index out of bounds: returns nullptr
-  TEST_ASSERT_NULL(
+  // Index out of bounds: returns false
+  TEST_ASSERT_FALSE(
     settings[ID_Strings]->getValuePtrOrDefault(settings[ID_Strings]->getSize(), &out, sizeof(out)));
 
-  // Buffer too small (size field = 0): returns nullptr
+  // Buffer too small (size field = 0): returns false
   NVS::Str tiny{buf, 0};
-  TEST_ASSERT_NULL(settings[ID_Strings]->getValuePtrOrDefault(0, &tiny, 0));
+  TEST_ASSERT_FALSE(settings[ID_Strings]->getValuePtrOrDefault(0, &tiny, 0));
 }
 
 void test_strings_format() {
@@ -1415,35 +1398,29 @@ void test_bytestreams_getValueOrDefault() {
 void test_bytestreams_getValuePtrOrDefault() {
   uint8_t buf[32];
   NVS::ByteStream out{buf, sizeof(buf)};
-  const void* result;
+  bool ok;
 
-  // Key exists in NVS (index 0 = Stream_1): returns non-null pointer to the NVS value
-  result = settings[ID_ByteStreams]->getValuePtrOrDefault(0, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
-  TEST_ASSERT_EQUAL_UINT32(new_bytestream[0].size,
-                           static_cast<const NVS::ByteStream*>(result)->size);
-  TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[0].data,
-                               static_cast<const NVS::ByteStream*>(result)->data,
-                               new_bytestream[0].size);
+  // Key exists in NVS (index 0 = Stream_1): returns true, out holds the NVS value
+  ok = settings[ID_ByteStreams]->getValuePtrOrDefault(0, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
+  TEST_ASSERT_EQUAL_UINT32(new_bytestream[0].size, out.size);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(new_bytestream[0].data, out.data, out.size);
 
-  // Key not in NVS (index 2 = Stream_3): returns non-null pointer to the default value
-  out    = {buf, sizeof(buf)};
-  result = settings[ID_ByteStreams]->getValuePtrOrDefault(2, &out, sizeof(out));
-  TEST_ASSERT_NOT_NULL(result);
+  // Key not in NVS (index 2 = Stream_3): returns true, out holds the default value
+  out = {buf, sizeof(buf)};
+  ok  = settings[ID_ByteStreams]->getValuePtrOrDefault(2, &out, sizeof(out));
+  TEST_ASSERT_TRUE(ok);
   NVS::ByteStreamView def3 = bytestreams.getDefaultValue(ByteStreams::Stream_3);
-  TEST_ASSERT_EQUAL_UINT32(def3.size, static_cast<const NVS::ByteStream*>(result)->size);
-  TEST_ASSERT_EQUAL_HEX8_ARRAY(
-    def3.data, static_cast<const NVS::ByteStream*>(result)->data, def3.size);
   TEST_ASSERT_EQUAL_UINT32(def3.size, out.size);
   TEST_ASSERT_EQUAL_HEX8_ARRAY(def3.data, out.data, out.size);
 
-  // Index out of bounds: returns nullptr
-  TEST_ASSERT_NULL(settings[ID_ByteStreams]->getValuePtrOrDefault(
+  // Index out of bounds: returns false
+  TEST_ASSERT_FALSE(settings[ID_ByteStreams]->getValuePtrOrDefault(
     settings[ID_ByteStreams]->getSize(), &out, sizeof(out)));
 
-  // Buffer too small (max_size = 0): returns nullptr
+  // Buffer too small (max_size = 0): returns false
   NVS::ByteStream tiny{buf, 0};
-  TEST_ASSERT_NULL(settings[ID_ByteStreams]->getValuePtrOrDefault(0, &tiny, 0));
+  TEST_ASSERT_FALSE(settings[ID_ByteStreams]->getValuePtrOrDefault(0, &tiny, 0));
 }
 
 void test_bytestreams_format() {


### PR DESCRIPTION
BREAKING CHANGE: now the library uses only the API of ESP-IDF NVS library, removing Preferences library dependency and extending the features. For detailed information, read the README.